### PR TITLE
v1.1.3 Added get history positions to bitget futures client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitget-api",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Node.js connector for Bitget REST APIs and WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/futures-client.ts
+++ b/src/futures-client.ts
@@ -316,6 +316,25 @@ export class FuturesClient extends BaseRestClient {
     });
   }
 
+  /** Get All historic positions, only supports Query within 3 monthso  */
+  getHistoryPositions(
+    startTime: string,
+    endTime: string,
+    productType?: FuturesProductType,
+    symbol?: string,
+    pageSize?: number,
+    lastEndId?: string,
+  ): Promise<APIResponse<FuturesPosition[]>> {
+    return this.getPrivate('/api/mix/v1/position/history-position', {
+      startTime,
+      endTime,
+      productType,
+      symbol,
+      pageSize,
+      lastEndId,
+    });
+  }
+
   /** Get Account Bill */
   getAccountBill(params: FuturesAccountBillRequest): Promise<APIResponse<any>> {
     return this.getPrivate('/api/mix/v1/account/accountBill', params);

--- a/src/futures-client.ts
+++ b/src/futures-client.ts
@@ -24,6 +24,7 @@ import {
   FuturesMarketTrade,
   FuturesPlanType,
   FuturesKlineInterval,
+  FuturesHistoricPositions,
 } from './types';
 import { REST_CLIENT_TYPE_ENUM } from './util';
 import BaseRestClient from './util/BaseRestClient';
@@ -316,23 +317,11 @@ export class FuturesClient extends BaseRestClient {
     });
   }
 
-  /** Get All historic positions, only supports Query within 3 monthso  */
+  /** Get All historic positions, only supports Query within 3 months  */
   getHistoryPositions(
-    startTime: string,
-    endTime: string,
-    productType?: FuturesProductType,
-    symbol?: string,
-    pageSize?: number,
-    lastEndId?: string,
+    params: FuturesHistoricPositions,
   ): Promise<APIResponse<FuturesPosition[]>> {
-    return this.getPrivate('/api/mix/v1/position/history-position', {
-      startTime,
-      endTime,
-      productType,
-      symbol,
-      pageSize,
-      lastEndId,
-    });
+    return this.getPrivate('/api/mix/v1/position/history-position', params);
   }
 
   /** Get Account Bill */

--- a/src/types/request/futures.ts
+++ b/src/types/request/futures.ts
@@ -88,6 +88,15 @@ export interface NewBatchFuturesOrder {
   clientOid?: string;
 }
 
+export interface FuturesHistoricPositions {
+  startTime: string;
+  endTime: string;
+  productType?: FuturesProductType;
+  symbol?: string;
+  pageSize?: number;
+  lastEndId?: string;
+}
+
 export interface FuturesPagination {
   startTime?: string;
   endTime?: string;


### PR DESCRIPTION
## Summary
Added get all history positions from https://bitgetlimited.github.io/apidoc/en/mix/#get-history-position to futures-client.ts

## Additional Information
startTime and endTime is required, max query is 3 months.