### PR TITLE
rest v1 spot & futures update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitget-api",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Node.js & JavaScript SDK for Bitget REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/futures-client.ts
+++ b/src/futures-client.ts
@@ -26,6 +26,7 @@ import {
   FuturesKlineInterval,
   FuturesHistoricPositions,
   ModifyFuturesOrder,
+  FuturesCandleData,
 } from './types';
 import { REST_CLIENT_TYPE_ENUM } from './util';
 import BaseRestClient from './util/BaseRestClient';
@@ -104,14 +105,16 @@ export class FuturesClient extends BaseRestClient {
     symbol: string,
     granularity: FuturesKlineInterval,
     startTime: string,
-    endTime: string,
+    endTime: string, 
     limit?: string,
-  ): Promise<any> {
+    kLineType?: 'market' | 'mark' | 'index'
+  ): Promise<FuturesCandleData[]> {
     return this.get('/api/mix/v1/market/candles', {
       symbol,
       granularity,
       startTime,
       endTime,
+      kLineType,
       limit,
     });
   }
@@ -559,12 +562,23 @@ export class FuturesClient extends BaseRestClient {
     return this.postPrivate('/api/mix/v1/plan/modifyTPSLPlan', params);
   }
 
-  /** Cancel Plan Order TPSL */
+  /** Cancel Plan Order (TPSL) */
   cancelPlanOrderTPSL(
     params: CancelFuturesPlanTPSL,
   ): Promise<APIResponse<any>> {
     return this.postPrivate('/api/mix/v1/plan/cancelPlan', params);
   }
+
+    /** Cancel Symbol Plan Order (TPSL) */
+    cancelSymbolPlanOrders(
+      symbol: string,
+      planType: FuturesPlanType,
+    ): Promise<APIResponse<any>> {
+      return this.postPrivate('/api/mix/v1/plan/cancelSymbolPlan', {
+        symbol,
+        planType,
+      });
+    }
 
   /** Cancel All Trigger Order (TPSL) */
   cancelAllPlanOrders(

--- a/src/spot-client.ts
+++ b/src/spot-client.ts
@@ -21,6 +21,7 @@ import {
   GetHistoricTradesParams,
   VIPFeeRate,
   SpotKlineInterval,
+  SpotCandleData,
 } from './types';
 import { REST_CLIENT_TYPE_ENUM } from './util';
 import BaseRestClient from './util/BaseRestClient';
@@ -111,12 +112,16 @@ export class SpotClient extends BaseRestClient {
   getCandles(
     symbol: string,
     period: SpotKlineInterval,
-    pagination?: Pagination,
-  ): Promise<APIResponse<any>> {
+    limit?: string,
+    after?: string,
+    before?: string,
+  ): Promise<APIResponse<SpotCandleData[]>> {
     return this.get('/api/spot/v1/market/candles', {
       symbol,
       period,
-      ...pagination,
+      limit,
+      after,
+      before
     });
   }
 

--- a/src/spot-client.ts
+++ b/src/spot-client.ts
@@ -112,16 +112,12 @@ export class SpotClient extends BaseRestClient {
   getCandles(
     symbol: string,
     period: SpotKlineInterval,
-    limit?: string,
-    after?: string,
-    before?: string,
+    pagination?: Pagination, 
   ): Promise<APIResponse<SpotCandleData[]>> {
     return this.get('/api/spot/v1/market/candles', {
       symbol,
       period,
-      limit,
-      after,
-      before
+      ...pagination,
     });
   }
 

--- a/src/types/request/v1/futuresV1.ts
+++ b/src/types/request/v1/futuresV1.ts
@@ -215,3 +215,5 @@ export interface HistoricPlanOrderTPSLRequest {
   isPre?: boolean;
   isPlan?: string;
 }
+
+export type FuturesCandleData = string[6];

--- a/src/types/request/v1/futuresV1.ts
+++ b/src/types/request/v1/futuresV1.ts
@@ -216,4 +216,14 @@ export interface HistoricPlanOrderTPSLRequest {
   isPlan?: string;
 }
 
+/**
+ * @typedef  {string[6]} FuturesCandleData
+ * @property {Array[0]} Timestamp in milliseconds
+ * @property {Array[1]} Opening price
+ * @property {Array[2]} Highest price
+ * @property {Array[3]} Lowest price
+ * @property {Array[4]} Closing price - Value of the latest candle stick might change
+ * @property {Array[5]} Base currency trading volume
+ * @property {Array[6]} Quote currency trading volume
+ */
 export type FuturesCandleData = string[6];

--- a/src/types/request/v1/spotV1.ts
+++ b/src/types/request/v1/spotV1.ts
@@ -127,12 +127,12 @@ export interface GetHistoricPlanOrdersParams {
 }
 
 export interface SpotCandleData {
-  open: string
-  high: string
-  low: string
-  close: string
-  quoteVol: string
-  baseVol: string
-  usdtVol: string
-  ts: string
+  open: string;
+  high: string;
+  low: string;
+  close: string;
+  quoteVol: string;
+  baseVol: string;
+  usdtVol: string;
+  ts: string;
 }

--- a/src/types/request/v1/spotV1.ts
+++ b/src/types/request/v1/spotV1.ts
@@ -3,22 +3,23 @@ import { OrderTimeInForce } from '../shared';
 export type WalletType = 'spot' | 'mix_usdt' | 'mix_usd';
 
 export type SpotKlineInterval =
-  | '1min'
-  | '5min'
-  | '15min'
-  | '30min'
-  | '1h'
-  | '4h'
-  | '6h'
-  | '12h'
-  | '1M'
-  | '1W'
-  | '1week'
-  | '6Hutc'
-  | '12Hutc'
-  | '1Dutc'
-  | '3Dutc'
-  | '1Wutc'
+  | '1min' 
+  | '5min' 
+  | '15min' 
+  | '30min' 
+  | '1h' 
+  | '4h' 
+  | '6h' 
+  | '12h' 
+  | '1day' 
+  | '3day' 
+  | '1week' 
+  | '1M' 
+  | '6Hutc' 
+  | '12Hutc' 
+  | '1Dutc' 
+  | '3Dutc' 
+  | '1Wutc' 
   | '1Mutc';
 
 export interface NewWalletTransfer {
@@ -123,4 +124,15 @@ export interface GetHistoricPlanOrdersParams {
   lastEndId?: string;
   startTime: string;
   endTime: string;
+}
+
+export interface SpotCandleData {
+  open: string
+  high: string
+  low: string
+  close: string
+  quoteVol: string
+  baseVol: string
+  usdtVol: string
+  ts: string
 }

--- a/src/types/response/futures.ts
+++ b/src/types/response/futures.ts
@@ -32,21 +32,30 @@ export interface FuturesAccount {
 }
 
 export interface FuturesSymbolRule {
-  baseCoin: string;
-  buyLimitPriceRatio: string;
-  feeRateUpRatio: string;
-  makerFeeRate: string;
-  minTradeNum: string;
-  openCostUpRatio: string;
-  priceEndStep: string;
-  pricePlace: string;
-  quoteCoin: string;
-  sellLimitPriceRatio: string;
-  sizeMultiplier: string;
-  supportMarginCoins: string[];
-  symbol: string;
-  takerFeeRate: string;
-  volumePlace: string;
+  baseCoin: string
+  buyLimitPriceRatio: string
+  feeRateUpRatio: string
+  limitOpenTime: string
+  maintainTime: string
+  makerFeeRate: string
+  maxOrderNum: string
+  maxPositionNum: string
+  minTradeNum: string
+  minTradeUSDT: string
+  offTime: string
+  openCostUpRatio: string
+  priceEndStep: string
+  pricePlace: string
+  quoteCoin: string
+  sellLimitPriceRatio: string
+  sizeMultiplier: string
+  supportMarginCoins: string[]
+  symbol: string
+  symbolName: string
+  symbolStatus: string
+  symbolType: string
+  takerFeeRate: string
+  volumePlace: string
 }
 
 export interface FuturesPosition {

--- a/src/types/response/futures.ts
+++ b/src/types/response/futures.ts
@@ -32,30 +32,30 @@ export interface FuturesAccount {
 }
 
 export interface FuturesSymbolRule {
-  baseCoin: string
-  buyLimitPriceRatio: string
-  feeRateUpRatio: string
-  limitOpenTime: string
-  maintainTime: string
-  makerFeeRate: string
-  maxOrderNum: string
-  maxPositionNum: string
-  minTradeNum: string
-  minTradeUSDT: string
-  offTime: string
-  openCostUpRatio: string
-  priceEndStep: string
-  pricePlace: string
-  quoteCoin: string
-  sellLimitPriceRatio: string
-  sizeMultiplier: string
-  supportMarginCoins: string[]
-  symbol: string
-  symbolName: string
-  symbolStatus: string
-  symbolType: string
-  takerFeeRate: string
-  volumePlace: string
+  baseCoin: string;
+  buyLimitPriceRatio: string;
+  feeRateUpRatio: string;
+  limitOpenTime: string;
+  maintainTime: string;
+  makerFeeRate: string;
+  maxOrderNum: string;
+  maxPositionNum: string;
+  minTradeNum: string;
+  minTradeUSDT: string;
+  offTime: string;
+  openCostUpRatio: string;
+  priceEndStep: string;
+  pricePlace: string;
+  quoteCoin: string;
+  sellLimitPriceRatio: string;
+  sizeMultiplier: string;
+  supportMarginCoins: string[];
+  symbol: string;
+  symbolName: string;
+  symbolStatus: string;
+  symbolType: string;
+  takerFeeRate: string;
+  volumePlace: string;
 }
 
 export interface FuturesPosition {


### PR DESCRIPTION
- add plan order symbol canceling
- fix candles data params (spot & futures)
- fix futures filter data (data in api-doc dither from real request!

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
