### PR TITLE
feat(v3.0.11): add new endpoints for open interest limit and tax records, update request/response types, and include example scripts

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -331,88 +331,90 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getServerTime()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L238) |  | GET | `/api/v3/public/time` |
-| [getInstruments()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L255) |  | GET | `/api/v3/market/instruments` |
-| [getTickers()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L264) |  | GET | `/api/v3/market/tickers` |
-| [getOrderBook()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L271) |  | GET | `/api/v3/market/orderbook` |
-| [getFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L280) |  | GET | `/api/v3/market/fills` |
-| [getProofOfReserves()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L289) |  | GET | `/api/v3/market/proof-of-reserves` |
-| [getOpenInterest()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L296) |  | GET | `/api/v3/market/open-interest` |
-| [getCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L305) |  | GET | `/api/v3/market/candles` |
-| [getHistoryCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L314) |  | GET | `/api/v3/market/history-candles` |
-| [getCurrentFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L323) |  | GET | `/api/v3/market/current-fund-rate` |
-| [getHistoryFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L332) |  | GET | `/api/v3/market/history-fund-rate` |
-| [getRiskReserve()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L341) |  | GET | `/api/v3/market/risk-reserve` |
-| [getDiscountRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L350) |  | GET | `/api/v3/market/discount-rate` |
-| [getMarginLoans()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L357) |  | GET | `/api/v3/market/margin-loans` |
-| [getPositionTier()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L366) |  | GET | `/api/v3/market/position-tier` |
-| [getContractsOi()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L375) |  | GET | `/api/v3/market/oi-limit` |
-| [getBalances()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L390) | :closed_lock_with_key:  | GET | `/api/v3/account/assets` |
-| [getFundingAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L397) | :closed_lock_with_key:  | GET | `/api/v3/account/funding-assets` |
-| [getAccountSettings()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L406) | :closed_lock_with_key:  | GET | `/api/v3/account/settings` |
-| [setLeverage()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L413) | :closed_lock_with_key:  | POST | `/api/v3/account/set-leverage` |
-| [setHoldMode()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L420) | :closed_lock_with_key:  | POST | `/api/v3/account/set-hold-mode` |
-| [getFinancialRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L429) | :closed_lock_with_key:  | GET | `/api/v3/account/financial-records` |
-| [getRepayableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L441) | :closed_lock_with_key:  | GET | `/api/v3/account/repayable-coins` |
-| [getPaymentCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L453) | :closed_lock_with_key:  | GET | `/api/v3/account/payment-coins` |
-| [submitRepay()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L465) | :closed_lock_with_key:  | POST | `/api/v3/account/repay` |
-| [getConvertRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L472) | :closed_lock_with_key:  | GET | `/api/v3/account/convert-records` |
-| [setDepositAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L487) | :closed_lock_with_key:  | POST | `/api/v3/account/deposit-account` |
-| [switchDeduct()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L496) | :closed_lock_with_key:  | POST | `/api/v3/account/switch-deduct` |
-| [getDeductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L503) | :closed_lock_with_key:  | GET | `/api/v3/account/deduct-info` |
-| [getFeeRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L514) | :closed_lock_with_key:  | GET | `/api/v3/account/fee-rate` |
-| [getMaxTransferable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L530) | :closed_lock_with_key:  | GET | `/api/v3/account/max-transferable` |
-| [downgradeAccountToClassic()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L545) | :closed_lock_with_key:  | POST | `/api/v3/account/switch` |
-| [getUnifiedAccountSwitchStatus()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L553) | :closed_lock_with_key:  | GET | `/api/v3/account/switch-status` |
-| [createSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L570) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub` |
-| [freezeSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L579) | :closed_lock_with_key:  | POST | `/api/v3/user/freeze-sub` |
-| [getSubUnifiedAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L588) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-unified-assets` |
-| [getSubAccountList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L597) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-list` |
-| [createSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L610) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub-api` |
-| [updateSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L619) | :closed_lock_with_key:  | POST | `/api/v3/user/update-sub-api` |
-| [deleteSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L628) | :closed_lock_with_key:  | POST | `/api/v3/user/delete-sub-api` |
-| [getSubAccountApiKeys()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L637) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-api-list` |
-| [getTransferableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L656) | :closed_lock_with_key:  | GET | `/api/v3/account/transferable-coins` |
-| [submitTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L665) | :closed_lock_with_key:  | POST | `/api/v3/account/transfer` |
-| [subAccountTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L674) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-transfer` |
-| [getSubTransferRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L686) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-transfer-record` |
-| [getDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L704) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-address` |
-| [getSubDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L713) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-deposit-address` |
-| [getDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L722) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-records` |
-| [getSubDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L731) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-deposit-records` |
-| [submitWithdraw()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L746) | :closed_lock_with_key:  | POST | `/api/v3/account/withdraw` |
-| [getWithdrawRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L755) | :closed_lock_with_key:  | GET | `/api/v3/account/withdrawal-records` |
-| [submitNewOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L770) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-order` |
-| [modifyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L779) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-order` |
-| [cancelOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L788) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-order` |
-| [placeBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L797) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-batch` |
-| [batchModifyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L806) | :closed_lock_with_key:  | POST | `/api/v3/trade/batch-modify-order` |
-| [cancelBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L815) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-batch` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L824) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-symbol-order` |
-| [closeAllPositions()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L833) | :closed_lock_with_key:  | POST | `/api/v3/trade/close-positions` |
-| [getOrderInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L842) | :closed_lock_with_key:  | GET | `/api/v3/trade/order-info` |
-| [getUnfilledOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L851) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-orders` |
-| [getHistoryOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L863) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-orders` |
-| [getTradeFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L875) | :closed_lock_with_key:  | GET | `/api/v3/trade/fills` |
-| [getCurrentPosition()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L887) | :closed_lock_with_key:  | GET | `/api/v3/position/current-position` |
-| [getPositionHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L898) | :closed_lock_with_key:  | GET | `/api/v3/position/history-position` |
-| [getMaxOpenAvailable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L910) | :closed_lock_with_key:  | POST | `/api/v3/account/max-open-available` |
-| [getPositionAdlRank()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L919) | :closed_lock_with_key:  | GET | `/api/v3/position/adlRank` |
-| [countdownCancelAll()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L926) | :closed_lock_with_key:  | POST | `/api/v3/trade/countdown-cancel-all` |
-| [getLoanTransfered()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L941) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/transfered` |
-| [getLoanSymbols()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L950) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/symbols` |
-| [getLoanRiskUnit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L959) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/risk-unit` |
-| [getLoanRepaidHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L970) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/repaid-history` |
-| [getLoanProductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L979) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/product-infos` |
-| [getLoanOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L988) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/loan-order` |
-| [getLoanLTVConvert()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L997) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ltv-convert` |
-| [getLoanMarginCoinInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1006) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ensure-coins-convert` |
-| [bindLoanUid()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1018) | :closed_lock_with_key:  | POST | `/api/v3/ins-loan/bind-uid` |
-| [submitStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1033) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-strategy-order` |
-| [modifyStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1042) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-strategy-order` |
-| [cancelStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1051) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-strategy-order` |
-| [getUnfilledStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1060) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-strategy-orders` |
-| [getHistoryStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1069) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-strategy-orders` |
+| [getServerTime()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L242) |  | GET | `/api/v3/public/time` |
+| [getInstruments()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L259) |  | GET | `/api/v3/market/instruments` |
+| [getTickers()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L268) |  | GET | `/api/v3/market/tickers` |
+| [getOrderBook()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L275) |  | GET | `/api/v3/market/orderbook` |
+| [getFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L284) |  | GET | `/api/v3/market/fills` |
+| [getProofOfReserves()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L293) |  | GET | `/api/v3/market/proof-of-reserves` |
+| [getOpenInterest()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L300) |  | GET | `/api/v3/market/open-interest` |
+| [getCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L310) |  | GET | `/api/v3/market/candles` |
+| [getHistoryCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L319) |  | GET | `/api/v3/market/history-candles` |
+| [getCurrentFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L328) |  | GET | `/api/v3/market/current-fund-rate` |
+| [getHistoryFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L337) |  | GET | `/api/v3/market/history-fund-rate` |
+| [getRiskReserve()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L346) |  | GET | `/api/v3/market/risk-reserve` |
+| [getDiscountRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L355) |  | GET | `/api/v3/market/discount-rate` |
+| [getMarginLoans()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L362) |  | GET | `/api/v3/market/margin-loans` |
+| [getPositionTier()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L371) |  | GET | `/api/v3/market/position-tier` |
+| [getContractsOi()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L380) |  | GET | `/api/v3/market/oi-limit` |
+| [getBalances()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L395) | :closed_lock_with_key:  | GET | `/api/v3/account/assets` |
+| [getFundingAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L402) | :closed_lock_with_key:  | GET | `/api/v3/account/funding-assets` |
+| [getAccountSettings()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L411) | :closed_lock_with_key:  | GET | `/api/v3/account/settings` |
+| [setLeverage()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L418) | :closed_lock_with_key:  | POST | `/api/v3/account/set-leverage` |
+| [setHoldMode()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L425) | :closed_lock_with_key:  | POST | `/api/v3/account/set-hold-mode` |
+| [getFinancialRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L434) | :closed_lock_with_key:  | GET | `/api/v3/account/financial-records` |
+| [getRepayableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L446) | :closed_lock_with_key:  | GET | `/api/v3/account/repayable-coins` |
+| [getPaymentCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L458) | :closed_lock_with_key:  | GET | `/api/v3/account/payment-coins` |
+| [submitRepay()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L470) | :closed_lock_with_key:  | POST | `/api/v3/account/repay` |
+| [getConvertRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L477) | :closed_lock_with_key:  | GET | `/api/v3/account/convert-records` |
+| [setDepositAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L492) | :closed_lock_with_key:  | POST | `/api/v3/account/deposit-account` |
+| [switchDeduct()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L501) | :closed_lock_with_key:  | POST | `/api/v3/account/switch-deduct` |
+| [getDeductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L508) | :closed_lock_with_key:  | GET | `/api/v3/account/deduct-info` |
+| [getFeeRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L519) | :closed_lock_with_key:  | GET | `/api/v3/account/fee-rate` |
+| [getMaxTransferable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L535) | :closed_lock_with_key:  | GET | `/api/v3/account/max-transferable` |
+| [getOpenInterestLimit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L547) | :closed_lock_with_key:  | GET | `/api/v3/account/open-interest-limit` |
+| [downgradeAccountToClassic()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L562) | :closed_lock_with_key:  | POST | `/api/v3/account/switch` |
+| [getUnifiedAccountSwitchStatus()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L570) | :closed_lock_with_key:  | GET | `/api/v3/account/switch-status` |
+| [getTaxRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L586) | :closed_lock_with_key:  | GET | `/api/v3/tax/records` |
+| [createSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L601) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub` |
+| [freezeSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L610) | :closed_lock_with_key:  | POST | `/api/v3/user/freeze-sub` |
+| [getSubUnifiedAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L619) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-unified-assets` |
+| [getSubAccountList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L628) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-list` |
+| [createSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L641) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub-api` |
+| [updateSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L650) | :closed_lock_with_key:  | POST | `/api/v3/user/update-sub-api` |
+| [deleteSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L659) | :closed_lock_with_key:  | POST | `/api/v3/user/delete-sub-api` |
+| [getSubAccountApiKeys()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L668) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-api-list` |
+| [getTransferableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L687) | :closed_lock_with_key:  | GET | `/api/v3/account/transferable-coins` |
+| [submitTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L696) | :closed_lock_with_key:  | POST | `/api/v3/account/transfer` |
+| [subAccountTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L705) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-transfer` |
+| [getSubTransferRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L717) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-transfer-record` |
+| [getDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L735) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-address` |
+| [getSubDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L744) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-deposit-address` |
+| [getDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L753) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-records` |
+| [getSubDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L762) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-deposit-records` |
+| [submitWithdraw()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L777) | :closed_lock_with_key:  | POST | `/api/v3/account/withdraw` |
+| [getWithdrawRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L786) | :closed_lock_with_key:  | GET | `/api/v3/account/withdrawal-records` |
+| [submitNewOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L801) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-order` |
+| [modifyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L810) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-order` |
+| [cancelOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L819) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-order` |
+| [placeBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L828) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-batch` |
+| [batchModifyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L837) | :closed_lock_with_key:  | POST | `/api/v3/trade/batch-modify-order` |
+| [cancelBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L846) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-batch` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L855) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-symbol-order` |
+| [closeAllPositions()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L864) | :closed_lock_with_key:  | POST | `/api/v3/trade/close-positions` |
+| [getOrderInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L873) | :closed_lock_with_key:  | GET | `/api/v3/trade/order-info` |
+| [getUnfilledOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L882) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-orders` |
+| [getHistoryOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L894) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-orders` |
+| [getTradeFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L906) | :closed_lock_with_key:  | GET | `/api/v3/trade/fills` |
+| [getCurrentPosition()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L918) | :closed_lock_with_key:  | GET | `/api/v3/position/current-position` |
+| [getPositionHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L929) | :closed_lock_with_key:  | GET | `/api/v3/position/history-position` |
+| [getMaxOpenAvailable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L941) | :closed_lock_with_key:  | POST | `/api/v3/account/max-open-available` |
+| [getPositionAdlRank()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L950) | :closed_lock_with_key:  | GET | `/api/v3/position/adlRank` |
+| [countdownCancelAll()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L957) | :closed_lock_with_key:  | POST | `/api/v3/trade/countdown-cancel-all` |
+| [getLoanTransfered()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L972) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/transfered` |
+| [getLoanSymbols()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L981) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/symbols` |
+| [getLoanRiskUnit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L990) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/risk-unit` |
+| [getLoanRepaidHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1001) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/repaid-history` |
+| [getLoanProductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1010) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/product-infos` |
+| [getLoanOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1019) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/loan-order` |
+| [getLoanLTVConvert()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1028) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ltv-convert` |
+| [getLoanMarginCoinInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1037) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ensure-coins-convert` |
+| [bindLoanUid()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1049) | :closed_lock_with_key:  | POST | `/api/v3/ins-loan/bind-uid` |
+| [submitStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1064) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-strategy-order` |
+| [modifyStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1073) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-strategy-order` |
+| [cancelStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1082) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-strategy-order` |
+| [getUnfilledStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1091) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-strategy-orders` |
+| [getHistoryStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1100) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-strategy-orders` |
 
 # websocket-api-client.ts
 

--- a/examples/apidoc/RestClientV3/getOpenInterestLimit.js
+++ b/examples/apidoc/RestClientV3/getOpenInterestLimit.js
@@ -1,0 +1,24 @@
+import { RestClientV3 } from 'bitget-api';
+// or if you want to use the require syntax
+// const { RestClientV3 } = require('bitget-api');
+
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/open-interest-limit
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getOpenInterestLimit(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getTaxRecords.js
+++ b/examples/apidoc/RestClientV3/getTaxRecords.js
@@ -1,0 +1,24 @@
+import { RestClientV3 } from 'bitget-api';
+// or if you want to use the require syntax
+// const { RestClientV3 } = require('bitget-api');
+
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/tax/records
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getTaxRecords(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/llms.txt
+++ b/llms.txt
@@ -51,6 +51,8 @@ Directory Structure
 examples/
   auth/
     fasterHmacSign.ts
+    rest-private-rsa.md
+    rest-private-rsa.ts
   deprecated-V1-REST/
     README.md
     rest-private-futures.ts
@@ -219,169 +221,6 @@ export interface BrokerSubAPIKeyModifyRequest {
   remark?: string;
   ip?: string;
   perm?: string;
-}
-
-================
-File: src/types/request/v2/broker.ts
-================
-/**
- *
- * * Broker | Subaccount
- *
- */
-⋮----
-export interface GetSubAccountsRequestV2 {
-  limit?: string;
-  idLessThan?: string;
-  status?: 'normal' | 'freeze' | 'del';
-  startTime?: string;
-  endTime?: string;
-}
-⋮----
-export type SubAccountPermissionV2 =
-  | 'withdraw'
-  | 'transfer'
-  | 'spot_trade'
-  | 'contract_trade'
-  | 'read'
-  | 'deposit'
-  | 'margin_trade';
-⋮----
-export type SubAccountLanguageV2 =
-  | 'en_US'
-  | 'zh_CN'
-  | 'ja_JP'
-  | 'vi_VN'
-  | 'zh_TW'
-  | 'ru_RU'
-  | 'es_ES'
-  | 'tr_TR'
-  | 'fr_FR'
-  | 'de_DE'
-  | 'pt_PT'
-  | 'th_TH';
-⋮----
-export type SubAccountStatusV2 = 'normal' | 'freeze';
-⋮----
-export interface ModifySubRequestV2 {
-  subUid: string;
-  permList: SubAccountPermissionV2[];
-  status: SubAccountStatusV2;
-  language?: SubAccountLanguageV2;
-}
-⋮----
-export interface SubWithdrawalRequestV2 {
-  subUid: string;
-  coin: string;
-  dest: 'on_chain' | 'internal_transfer';
-  chain?: string;
-  address: string;
-  amount: string;
-  tag?: string;
-  clientOid?: string;
-}
-⋮----
-export interface SubDepositRecordsRequestV2 {
-  orderId?: string;
-  userId?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  idLessThan?: string;
-}
-⋮----
-export interface SubWithdrawalRecordsRequestV2 {
-  orderId?: string;
-  userId?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  idLessThan?: string;
-}
-⋮----
-/**
- *
- * * Broker | Subaccount
- *
- */
-⋮----
-export interface CreateSubAccountApiKeyRequestV2 {
-  subUid: string;
-  passphrase: string;
-  label?: string;
-  ipList: string[];
-  permType: string;
-  permList: string[];
-}
-⋮----
-export interface ModifySubAccountApiKeyRequestV2 {
-  subUid: string;
-  apiKey: string;
-  label?: string;
-  passphrase: string;
-  ipList?: string[];
-  permType?: string;
-  permList: string[];
-}
-⋮----
-/**
- *
- * * Broker | All Sub-accounts Deposit and Withdrawal Records
- *
- */
-⋮----
-export interface GetAllSubDepositWithdrawalRequestV2 {
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  idLessThan?: string;
-  type?: 'all' | 'deposit' | 'withdrawal';
-}
-⋮----
-/**
- *
- * * Broker | Subaccounts
- *
- */
-⋮----
-export interface GetBrokerSubaccountsRequestV2 {
-  startTime?: string;
-  endTime?: string;
-  pageSize?: string;
-  pageNo?: string;
-}
-⋮----
-/**
- *
- * * Broker | Commissions
- *
- */
-⋮----
-export interface GetBrokerCommissionsRequestV2 {
-  startTime?: string;
-  endTime?: string;
-  pageSize?: string;
-  pageNo?: string;
-  bizType?: 'spot' | 'futures';
-  subBizType?:
-    | 'spot_trade'
-    | 'spot_margin'
-    | 'usdt_futures'
-    | 'usdc_futures'
-    | 'coin_futures';
-}
-⋮----
-/**
- *
- * * Broker | Trade Volume
- *
- */
-⋮----
-export interface GetBrokerTradeVolumeRequestV2 {
-  startTime?: string;
-  endTime?: string;
-  pageSize?: string;
-  pageNo?: string;
 }
 
 ================
@@ -1412,6 +1251,228 @@ export interface GetTickersRequestV3 {
 }
 
 ================
+File: src/types/request/v3/strategy.ts
+================
+export interface PlaceStrategyOrderRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  clientOid?: string;
+  type?: 'tpsl';
+  tpslMode?: 'full' | 'partial';
+  qty: string;
+  posSide: 'long' | 'short';
+  tpTriggerBy?: 'market' | 'mark';
+  slTriggerBy?: 'market' | 'mark';
+  takeProfit?: string;
+  stopLoss?: string;
+  tpOrderType?: 'limit' | 'market';
+  slOrderType?: 'limit' | 'market';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+}
+⋮----
+export interface ModifyStrategyOrderRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+  qty: string;
+  tpTriggerBy?: 'market' | 'mark';
+  slTriggerBy?: 'market' | 'mark';
+  takeProfit?: string;
+  stopLoss?: string;
+  tpOrderType?: 'limit' | 'market';
+  slOrderType?: 'limit' | 'market';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+}
+⋮----
+export interface CancelStrategyOrderRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+export interface GetUnfilledStrategyOrdersRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  type?: 'tpsl';
+}
+⋮----
+export interface GetHistoryStrategyOrdersRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  type?: 'tpsl';
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  cursor?: string;
+}
+
+================
+File: src/types/request/v3/trade.ts
+================
+export interface BatchModifyOrderRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+  qty?: string;
+  price?: string;
+  autoCancel?: 'yes' | 'no';
+}
+⋮----
+export interface CancelAllOrdersRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol?: string;
+}
+⋮----
+export interface CancelBatchOrdersRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol: string;
+}
+⋮----
+export interface CloseAllPositionsRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  posSide?: 'long' | 'short';
+}
+⋮----
+export interface CancelOrderRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+export interface GetMaxOpenAvailableRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol: string;
+  orderType: 'limit' | 'market';
+  side: 'buy' | 'sell';
+  price?: string;
+  size?: string;
+}
+⋮----
+export interface GetOrderInfoRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+export interface GetFillsRequestV3 {
+  orderId?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetUnfilledOrdersRequestV3 {
+  category?:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetHistoryOrdersRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetPositionHistoryRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetCurrentPositionRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  posSide?: 'long' | 'short';
+}
+⋮----
+export interface ModifyOrderRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+  qty?: string;
+  price?: string;
+  autoCancel?: 'yes' | 'no';
+}
+⋮----
+export interface PlaceBatchOrdersRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol: string;
+  qty: string;
+  price?: string;
+  side: 'buy' | 'sell';
+  orderType: 'limit' | 'market';
+  timeInForce?: 'ioc' | 'fok' | 'gtc' | 'post_only';
+  posSide?: 'long' | 'short';
+  clientOid?: string;
+  reduceOnly?: 'yes' | 'no';
+}
+⋮----
+export interface PlaceOrderRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol: string;
+  qty: string;
+  price?: string;
+  side: 'buy' | 'sell';
+  orderType: 'limit' | 'market';
+  timeInForce?: 'ioc' | 'fok' | 'gtc' | 'post_only';
+  posSide?: 'long' | 'short';
+  clientOid?: string;
+  reduceOnly?: 'yes' | 'no';
+  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
+  takeProfitPrice?: string;
+  stopLossPrice?: string;
+  takeProfitTriggerType?: 'mark_price' | 'last_price';
+  stopLossTriggerType?: 'mark_price' | 'last_price';
+}
+⋮----
+export interface CountdownCancelAllRequestV3 {
+  countdown: string; // seconds until auto-cancel (5-60, or 0 to disable)
+}
+⋮----
+countdown: string; // seconds until auto-cancel (5-60, or 0 to disable)
+
+================
 File: src/types/request/shared.ts
 ================
 /** Pagination */
@@ -1560,220 +1621,6 @@ export interface SpotAccountBill {
 }
 ⋮----
 | string; // TODO: complete list of possible values here?
-
-================
-File: src/types/response/v2/broker.ts
-================
-/**
- *
- * * Broker | Subaccount
- *
- */
-⋮----
-export interface CreateSubaccountResponseV2 {
-  subUid: string;
-  subaccountName: string;
-  status: string;
-  permList: string[];
-  label: string;
-  cTime: string;
-}
-⋮----
-export interface BrokerSubaccountV2 {
-  subUid: string;
-  subaccountName: string;
-  status: string;
-  permList: string[];
-  label: string;
-  language: string;
-  cTime: string;
-  uTime: string;
-}
-⋮----
-export interface ModifySubaccountResponseV2 {
-  subUid: string;
-  subaccountName: string;
-  status: string;
-  permList: string[];
-  label: string;
-  language: string;
-  cTime: string;
-  uTime: string;
-}
-⋮----
-export interface SubaccountEmailV2 {
-  subUid: string;
-  subaccountName: string;
-  subaccountEmail: string;
-  cTime: string;
-  uTime: string;
-}
-⋮----
-export interface BrokerSubaccountSpotAssetV2 {
-  coin: string;
-  available: string;
-  frozen: string;
-  locked: string;
-  uTime: string;
-}
-⋮----
-export interface BrokerSubaccountFutureAssetV2 {
-  marginCoin: string;
-  available: string;
-  frozen: string;
-  locked: string;
-  crossedMaxAvailable: string;
-  isolatedMaxAvailable: string;
-  maxTransferOut: string;
-  accountEquity: string;
-  usdtEquity: string;
-  btcEquity: string;
-  uTime: string;
-}
-⋮----
-export interface CreateSubaccountDepositAddressV2 {
-  subUid: string;
-  coin: string;
-  address: string;
-  chain: string;
-  tag: string;
-  url: string;
-  cTime: string;
-}
-⋮----
-export interface SubaccountDepositV2 {
-  orderId: string;
-  txId: string;
-  coin: string;
-  type: string;
-  dest: string;
-  amount: string;
-  status: string;
-  fromAddress: string;
-  toAddress: string;
-  fee: string;
-  chain: string;
-  confirm: string;
-  tag: string;
-  cTime: string;
-  uTime: string;
-}
-⋮----
-export interface BrokerSubaccountWithdrawalV2 {
-  orderId: string;
-  txId: string;
-  coin: string;
-  type: string;
-  dest: string;
-  amount: string;
-  status: string;
-  fromAddress: string;
-  toAddress: string;
-  fee: string;
-  chain: string;
-  confirm: string;
-  tag: string;
-  userId: string;
-  cTime: string;
-  uTime: string;
-}
-⋮----
-/**
- *
- *  Broker | Api Key
- *
- */
-⋮----
-export interface CreateSubaccountApiKeyResponseV2 {
-  subUid: string;
-  apiKey: string;
-  secretKey: string;
-  label: string;
-  ipList: string[];
-  permType: string;
-  permList: string[];
-}
-⋮----
-export interface SubaccountApiKeyV2 {
-  subUid: string;
-  label: string;
-  apiKey: string;
-  secretKey: string;
-  permType: string;
-  permList: string[];
-  ipList: string[];
-}
-⋮----
-export interface ModifySubaccountApiKeyResponseV2 {
-  subUid: string;
-  apiKey: string;
-  label: string;
-  ipList: string[];
-  permType: string;
-  permList: string[];
-}
-⋮----
-/**
- *
- * * Broker | All Sub-accounts Deposit and Withdrawal Records
- *
- */
-⋮----
-export interface AllSubDepositWithdrawalRecordV2 {
-  uid: string;
-  txId: string;
-  type: 'deposit' | 'withdrawal';
-  subType: 'onchain' | 'internal' | 'fast';
-  coin: string;
-  amount: string;
-  status: 'pending' | 'fail' | 'success';
-  ts: string;
-}
-⋮----
-/**
- *
- * * Broker | Subaccounts
- *
- */
-⋮----
-export interface BrokerSubaccountInfoV2 {
-  uid: string;
-  asset: string;
-  firstTimeDeposit: string;
-  firstTimeTrade: string;
-  registerTime: string;
-}
-⋮----
-/**
- *
- * * Broker | Commissions
- *
- */
-⋮----
-export interface BrokerCommissionV2 {
-  uid: string;
-  coin: string;
-  symbol: string;
-  dealtAmount: string;
-  totalFee: string;
-  deductedFee: string;
-  paidFee: string;
-  markUpFee: string;
-  totalCommission: string;
-}
-⋮----
-/**
- *
- * * Broker | Trade Volume
- *
- */
-⋮----
-export interface BrokerTradeVolumeV2 {
-  uid: string;
-  volume: string;
-  spotVolume: string;
-  futureVolume: string;
-}
 
 ================
 File: src/types/response/v2/common.ts
@@ -2959,630 +2806,6 @@ export interface EarnLoanLiquidationRecordsV2 {
 }
 
 ================
-File: src/types/response/v2/futures.ts
-================
-/**
- *
- * * Futures | Market
- *
- */
-⋮----
-export interface FuturesVipFeeRateV2 {
-  level: string;
-  dealAmount: string;
-  assetAmount: string;
-  takerFeeRate: string;
-  makerFeeRate: string;
-  btcWithdrawAmount: string;
-  usdtWithdrawAmount: string;
-}
-⋮----
-export interface FuturesHistoryInterestRateV2 {
-  ts: string;
-  annualInterestRate: string;
-  dailyInterestRate: string;
-}
-⋮----
-export interface FuturesInterestExchangeRateV2 {
-  tier: string;
-  minAmount: string;
-  maxAmount: string;
-  exchangeRate: string;
-}
-⋮----
-export interface FuturesDiscountRateV2 {
-  tier: string;
-  minAmount: string;
-  maxAmount: string;
-  discountRate: string;
-}
-⋮----
-export interface FuturesDiscountRatesV2 {
-  coin: string;
-  userLimit: string;
-  totalLimit: string;
-  discountRateList: FuturesDiscountRateV2[];
-}
-⋮----
-export interface FuturesMergeDepthV2 {
-  asks: [number, number][];
-  bids: [number, number][];
-  ts: string;
-  scale: string;
-  precision: string;
-  isMaxPrecision: string;
-}
-⋮----
-export interface FuturesTickerV2 {
-  symbol: string;
-  lastPr: string;
-  askPr: string;
-  bidPr: string;
-  bidSz: string;
-  askSz: string;
-  high24h: string;
-  low24h: string;
-  ts: string;
-  change24h: string;
-  baseVolume: string;
-  quoteVolume: string;
-  usdtVolume: string;
-  openUtc: string;
-  changeUtc24h: string;
-  indexPrice: string;
-  fundingRate: string;
-  holdingAmount: string;
-  deliveryStartTime: string;
-  deliveryTime: string;
-  deliveryStatus: string;
-  open24h: string;
-  markPrice: string;
-}
-⋮----
-export interface FuturesFillV2 {
-  tradeId: string;
-  price: string;
-  size: string;
-  side: string;
-  ts: string;
-  symbol: string;
-}
-⋮----
-export type FuturesCandlestickV2 = [
-  string, // timestamp
-  string, // open
-  string, // high
-  string, // low
-  string, // close
-  string, // baseVolume
-  string, // usdtVolume
-  string, // quoteVolume
-];
-⋮----
-string, // timestamp
-string, // open
-string, // high
-string, // low
-string, // close
-string, // baseVolume
-string, // usdtVolume
-string, // quoteVolume
-⋮----
-export interface FuturesOpenInterestV2 {
-  symbol: string;
-  size: string;
-}
-⋮----
-export interface FuturesFundingTimeV2 {
-  symbol: string;
-  nextFundingTime: string;
-  ratePeriod: string;
-}
-⋮----
-export interface FuturesSymbolPriceV2 {
-  symbol: string;
-  price: string;
-  indexPrice: string;
-  markPrice: string;
-  ts: string;
-}
-⋮----
-export interface FuturesHistoricalFundingRateV2 {
-  symbol: string;
-  fundingRate: string;
-  fundingTime: string;
-}
-⋮----
-export interface FuturesContractConfigV2 {
-  symbol: string;
-  baseCoin: string;
-  quoteCoin: string;
-  buyLimitPriceRatio: string;
-  sellLimitPriceRatio: string;
-  feeRateUpRatio: string;
-  makerFeeRate: string;
-  takerFeeRate: string;
-  openCostUpRatio: string;
-  supportMarginCoins: string[];
-  minTradeNum: string;
-  priceEndStep: string;
-  volumePlace: string;
-  pricePlace: string;
-  sizeMultiplier: string;
-  symbolType: string;
-  minTradeUSDT: string;
-  maxSymbolOrderNum: string;
-  maxProductOrderNum: string;
-  maxPositionNum: string;
-  symbolStatus: string;
-  offTime: string;
-  limitOpenTime: string;
-  deliveryTime: string;
-  deliveryStartTime: string;
-  launchTime: string;
-  fundInterval: string;
-  minLever: string;
-  maxLever: string;
-  posLimit: string;
-  maintainTime: string;
-}
-⋮----
-/**
- *
- * * Futures | Account
- *
- */
-⋮----
-export interface FuturesAccountV2 {
-  marginCoin: string;
-  locked: string;
-  available: string;
-  crossedMaxAvailable: string;
-  isolatedMaxAvailable: string;
-  maxTransferOut: string;
-  accountEquity: string;
-  usdtEquity: string;
-  btcEquity: string;
-  crossedRiskRate: string;
-  crossedMarginLeverage: string;
-  isolatedLongLever: string;
-  isolatedShortLever: string;
-  marginMode: string;
-  posMode: string;
-  unrealizedPL: string;
-  coupon: string;
-  crossedUnrealizedPL: string;
-  isolatedUnrealizedPL: string;
-  assetMode: string;
-}
-⋮----
-export interface FuturesAccountsV2 {
-  marginCoin: string;
-  locked: string;
-  available: string;
-  crossedMaxAvailable: string;
-  isolatedMaxAvailable: string;
-  maxTransferOut: string;
-  accountEquity: string;
-  usdtEquity: string;
-  btcEquity: string;
-  crossedRiskRate: string;
-  unrealizedPL: string;
-  coupon: string;
-  unionTotalMagin: string;
-  unionAvailable: string;
-  unionMm: string;
-  assetList: {
-    coin: string;
-    balance: string;
-  }[];
-  isolatedMargin: string;
-  crossedMargin: string;
-  crossedUnrealizedPL: string;
-  isolatedUnrealizedPL: string;
-  assetMode: string;
-}
-⋮----
-export interface FuturesSubAccountAssetV2 {
-  marginCoin: string;
-  locked: string;
-  available: string;
-  crossedMaxAvailable: string;
-  isolatedMaxAvailable: string;
-  maxTransferOut: string;
-  accountEquity: string;
-  usdtEquity: string;
-  btcEquity: string;
-  unrealizedPL: string;
-  coupon: string;
-}
-⋮----
-export interface FuturesInterestV2 {
-  coin: string;
-  liability: string;
-  interestFreeLimit: string;
-  interestLimit: string;
-  hourInterestRate: string;
-  interest: string;
-  cTime: string;
-}
-export interface FuturesInterestHistoryV2 {
-  nextSettleTime: string;
-  borrowAmount: string;
-  borrowLimit: string;
-  interestList: FuturesInterestV2[];
-  endId: string;
-}
-⋮----
-export interface SetLeverageResponseV2 {
-  symbol: string;
-  marginCoin: string;
-  longLeverage: string;
-  shortLeverage: string;
-  crossMarginLeverage: string;
-  marginMode: string;
-}
-⋮----
-export interface SetMarginModeResponseV2 {
-  symbol: string;
-  marginCoin: string;
-  longLeverage: string;
-  shortLeverage: string;
-  marginMode: string;
-}
-⋮----
-export interface FuturesAccountBillV2 {
-  billId: string;
-  symbol: string;
-  amount: string;
-  fee: string;
-  feeByCoupon: string;
-  businessType: string;
-  coin: string;
-  balance: string;
-  cTime: string;
-}
-⋮----
-/**
- *
- * * Futures | Position
- *
- */
-⋮----
-export interface FuturesPositionTierV2 {
-  symbol: string;
-  level: string;
-  startUnit: string;
-  endUnit: string;
-  leverage: string;
-  keepMarginRate: string;
-}
-⋮----
-export interface FuturesPositionV2 {
-  marginCoin: string;
-  symbol: string;
-  holdSide: string;
-  openDelegateSize: string;
-  marginSize: string;
-  available: string;
-  locked: string;
-  total: string;
-  leverage: string;
-  achievedProfits: string;
-  openPriceAvg: string;
-  marginMode: string;
-  posMode: string;
-  unrealizedPL: string;
-  liquidationPrice: string;
-  keepMarginRate: string;
-  markPrice: string;
-  breakEvenPrice: string;
-  totalFee: string;
-  deductedFee: string;
-  marginRatio: string;
-  assetMode: string;
-  uTime: string;
-  autoMargin: string;
-  cTime: string;
-}
-⋮----
-export interface FuturesHistoryPositionV2 {
-  positionId: string;
-  marginCoin: string;
-  symbol: string;
-  holdSide: string;
-  openAvgPrice: string;
-  closeAvgPrice: string;
-  marginMode: string;
-  openTotalPos: string;
-  closeTotalPos: string;
-  pnl: string;
-  netProfit: string;
-  totalFunding: string;
-  openFee: string;
-  closeFee: string;
-  cTime: string;
-  uTime: string;
-}
-⋮----
-/**
- *
- * * Futures | Trade
- *
- */
-⋮----
-export interface FuturesBatchOrderResponseV2 {
-  successList: {
-    orderId: string;
-    clientOid: string;
-  }[];
-  failureList: {
-    orderId: string;
-    clientOid: string;
-    errorMsg: string;
-    errorCode: string;
-  }[];
-}
-⋮----
-export interface FuturesClosePositionResponseV2 {
-  successList: {
-    orderId: string;
-    clientOid: string;
-    symbol: string;
-  }[];
-  failureList: {
-    orderId: string;
-    clientOid: string;
-    symbol: string;
-    errorMsg: string;
-    errorCode: string;
-  }[];
-}
-⋮----
-export interface FuturesOrderDetailV2 {
-  symbol: string;
-  size: string;
-  orderId: string;
-  clientOid: string;
-  baseVolume: string;
-  priceAvg: string;
-  fee: string;
-  price: string;
-  state: string;
-  side: string;
-  force: string;
-  totalProfits: string;
-  posSide: string;
-  marginCoin: string;
-  presetStopSurplusPrice: string;
-  presetStopLossPrice: string;
-  quoteVolume: string;
-  orderType: string;
-  leverage: string;
-  marginMode: string;
-  reduceOnly: string;
-  enterPointSource: string;
-  tradeSide: string;
-  posMode: string;
-  orderSource: string;
-  cancelReason: string;
-  cTime: string;
-  uTime: string;
-}
-⋮----
-export interface FuturesOrderFillV2 {
-  tradeId: string;
-  symbol: string;
-  orderId: string;
-  price: string;
-  baseVolume: string;
-  feeDetail: {
-    deduction: string;
-    feeCoin: string;
-    totalDeductionFee: string;
-    totalFee: string;
-  }[];
-  side: string;
-  quoteVolume: string;
-  profit: string;
-  enterPointSource: string;
-  tradeSide: string;
-  posMode: string;
-  tradeScope: string;
-  cTime: string;
-}
-⋮----
-export interface FuturesOpenOrderV2 {
-  symbol: string;
-  size: string;
-  orderId: string;
-  clientOid: string;
-  baseVolume: string;
-  fee: string;
-  price: string;
-  priceAvg: string;
-  status: string;
-  side: string;
-  force: string;
-  totalProfits: string;
-  posSide: string;
-  marginCoin: string;
-  quoteVolume: string;
-  leverage: string;
-  marginMode: string;
-  enterPointSource: string;
-  tradeSide: string;
-  posMode: string;
-  orderType: string;
-  orderSource: string;
-  cTime: string;
-  uTime: string;
-  presetStopSurplusPrice: string;
-  presetStopSurplusType: string;
-  presetStopSurplusExecutePrice: string;
-  presetStopLossPrice: string;
-  presetStopLossType: string;
-  presetStopLossExecutePrice: string;
-}
-⋮----
-export interface FuturesHistoryOrderV2 {
-  symbol: string;
-  size: string;
-  orderId: string;
-  clientOid: string;
-  baseVolume: string;
-  fee: string;
-  price: string;
-  priceAvg: string;
-  status: string;
-  side: string;
-  force: string;
-  totalProfits: string;
-  posSide: string;
-  marginCoin: string;
-  quoteVolume: string;
-  leverage: string;
-  marginMode: string;
-  enterPointSource: string;
-  tradeSide: string;
-  posMode: string;
-  orderType: string;
-  orderSource: string;
-  cTime: string;
-  uTime: string;
-  presetStopSurplusPrice: string;
-  presetStopLossPrice: string;
-}
-⋮----
-export interface FuturesCancelAllOrdersV2 {
-  successList: {
-    orderId: string;
-    clientOid: string;
-  }[];
-  failureList: {
-    orderId: string;
-    clientOid: string;
-    errorMsg: string;
-    errorCode: string;
-  }[];
-}
-⋮----
-/**
- *
- * * Futures | Trigger Orders
- *
- */
-⋮----
-export interface FuturesTriggerSubOrderV2 {
-  orderId: string;
-  price: string;
-  type: string;
-  status: string;
-}
-⋮----
-export interface FuturesPendingPlanOrderV2 {
-  planType: string;
-  symbol: string;
-  size: string;
-  orderId: string;
-  clientOid: string;
-  price: string;
-  executePrice: string;
-  callbackRatio: string;
-  triggerPrice: string;
-  triggerType: string;
-  planStatus: string;
-  side: string;
-  posSide: string;
-  marginCoin: string;
-  marginMode: string;
-  enterPointSource: string;
-  tradeSide: string;
-  posMode: string;
-  orderType: string;
-  orderSource: string;
-  cTime: string;
-  uTime: string;
-  stopSurplusExecutePrice: string;
-  stopSurplusTriggerPrice: string;
-  stopSurplusTriggerType: string;
-  stopLossExecutePrice: string;
-  stopLossTriggerPrice: string;
-  stopLossTriggerType: string;
-}
-⋮----
-export interface FuturesCancelPlanOrderV2 {
-  successList: {
-    orderId: string;
-    clientOid: string;
-  }[];
-  failureList: {
-    orderId: string;
-    clientOid: string;
-    errorMsg: string;
-  }[];
-}
-⋮----
-export interface FuturesHistoryPlanOrderV2 {
-  planType: string;
-  symbol: string;
-  size: string;
-  orderId: string;
-  executeOrderId: string;
-  clientOid: string;
-  planStatus: string;
-  price: string;
-  executePrice: string;
-  priceAvg: string;
-  baseVolume: string;
-  callbackRatio: string;
-  triggerPrice: string;
-  triggerType: string;
-  side: string;
-  posSide: string;
-  marginCoin: string;
-  marginMode: string;
-  enterPointSource: string;
-  tradeSide: string;
-  posMode: string;
-  orderType: string;
-  cTime: string;
-  uTime: string;
-  stopSurplusExecutePrice: string;
-  stopSurplusTriggerPrice: string;
-  stopSurplusTriggerType: string;
-  stopLossExecutePrice: string;
-  stopLossTriggerPrice: string;
-  stopLossTriggerType: string;
-}
-⋮----
-/**
- *
- * * Futures | Union Margin
- *
- */
-⋮----
-export interface UnionTransferLimitsV2 {
-  coin: string;
-  maxTransferIn: string;
-}
-⋮----
-export interface UnionConfigV2 {
-  imr: string;
-  mmr: string;
-  individualLimit: string;
-  individualLimitRatio: string;
-}
-⋮----
-export interface UnionSwitchUsdtV2 {
-  usdtAmount: string;
-}
-⋮----
-export interface UnionConvertV2 {
-  usdtAmount: string;
-}
-
-================
 File: src/types/response/v2/margin.ts
 ================
 /**
@@ -4316,6 +3539,232 @@ export interface SpotDepositRecordV2 {
 }
 
 ================
+File: src/types/response/v3/loan.ts
+================
+export interface LoanTransfersV3 {
+  coin: string;
+  transfered: string;
+  userId: string;
+}
+⋮----
+export interface LoanSymbolSettingV3 {
+  symbol: string;
+  leverage: string;
+}
+⋮----
+export interface LoanSymbolsV3 {
+  productId: string;
+  spotSymbols: string[];
+  marginLeverage: string;
+  usdtContractLeverage: string;
+  coinContractLeverage: string;
+  usdcContractLeverage: string;
+  usdtContractSymbols: LoanSymbolSettingV3[];
+  coinContractSymbols: LoanSymbolSettingV3[];
+  usdcContractSymbols: LoanSymbolSettingV3[];
+}
+⋮----
+export interface RepaidHistoryItemV3 {
+  repayOrderId: string;
+  businessType: 'normal' | 'liquidation';
+  repayType: 'all' | 'part';
+  repaidTime: string;
+  coin: string;
+  repayAmount: string;
+  repayInterest: string;
+}
+⋮----
+export interface LoanProductInfoV3 {
+  productId: string;
+  leverage: string;
+  supportUsdtContract: 'YES' | 'NO';
+  supportCoinContract: 'YES' | 'NO';
+  supportUsdcContract: 'YES' | 'NO';
+  transferLine: string;
+  spotBuyLine: string;
+  usdtContractOpenLine: string;
+  coinContractOpenLine: string;
+  usdcContractOpenLine: string;
+  liquidationLine: string;
+  stopLiquidationLine: string;
+}
+⋮----
+export interface LoanOrderV3 {
+  orderId: string;
+  orderProductId: string;
+  uid: string;
+  loanTime: string;
+  loanCoin: string;
+  loanAmount: string;
+  unpaidAmount: string;
+  unpaidInterest: string;
+  repaidAmount: string;
+  repaidInterest: string;
+  reserve: string;
+  status: 'not_paid_off' | 'paid_off';
+}
+⋮----
+export interface CoinInfoV3 {
+  coin: string;
+  convertRatio: string;
+  maxConvertValue: string;
+}
+⋮----
+export interface BindUidResponseV3 {
+  riskUnitId: string;
+  uid: string;
+  operate: 'bind' | 'unbind';
+}
+⋮----
+export interface UnpaidInfoV3 {
+  coin: string;
+  unpaidQty: string;
+  unpaidInterest: string;
+}
+⋮----
+export interface BalanceInfoV3 {
+  coin: string;
+  price: string;
+  amount: string;
+  convertedUsdtAmount: string;
+}
+⋮----
+export interface LTVConvertResponseV3 {
+  ltv: string;
+  subAccountUids: string[];
+  unpaidUsdtAmount: string;
+  usdtBalance: string;
+  unpaidInfo: UnpaidInfoV3[];
+  balanceInfo: BalanceInfoV3[];
+}
+
+================
+File: src/types/response/v3/strategy.ts
+================
+export interface PlaceStrategyOrderResponseV3 {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface ModifyStrategyOrderResponseV3 {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface StrategyOrderV3 {
+  orderId: string;
+  clientOid: string;
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  qty: string;
+  posSide: 'long' | 'short';
+  tpTriggerBy: 'market' | 'mark';
+  slTriggerBy: 'market' | 'mark';
+  takeProfit: string;
+  stopLoss: string;
+  tpOrderType: 'limit' | 'market';
+  slOrderType: 'limit' | 'market';
+  tpLimitPrice: string;
+  slLimitPrice: string;
+  createdTime: string;
+  updatedTime: string;
+}
+
+================
+File: src/types/websockets/ws-events.ts
+================
+export interface MessageEventLike {
+  target: WebSocket;
+  type: 'message';
+  data: string;
+}
+⋮----
+export function isMessageEvent(msg: unknown): msg is MessageEventLike
+⋮----
+export interface WsBaseEvent<TAction = 'snapshot' | string, TData = unknown> {
+  action: TAction;
+  arg: unknown;
+  data: TData[];
+}
+⋮----
+export interface WsSnapshotChannelEvent extends WsBaseEvent<'snapshot'> {
+  arg: {
+    instType: string;
+    channel: string;
+    instId: string;
+  };
+}
+⋮----
+export interface WsSnapshotAccountEvent extends WsBaseEvent<'snapshot'> {
+  arg: {
+    instType: string;
+    channel: 'account';
+    instId: string;
+  };
+}
+⋮----
+export interface WsSnapshotPositionsEvent extends WsBaseEvent<'snapshot'> {
+  arg: {
+    instType: string;
+    channel: 'positions';
+    instId: string;
+  };
+}
+⋮----
+export interface WsAccountSnapshotDataUMCBL {
+  marginCoin: string;
+  locked: string;
+  available: string;
+  maxOpenPosAvailable: string;
+  maxTransferOut: string;
+  equity: string;
+  usdtEquity: string;
+}
+⋮----
+export interface WsAccountSnapshotUMCBL extends WsBaseEvent<'snapshot'> {
+  arg: {
+    instType: 'umcbl';
+    channel: 'account';
+    instId: string;
+  };
+  data: WsAccountSnapshotDataUMCBL[];
+}
+⋮----
+export interface WsPositionSnapshotDataUMCBL {
+  posId: string;
+  instId: string;
+  instName: string;
+  marginCoin: string;
+  margin: string;
+  marginMode: string;
+  holdSide: string;
+  holdMode: string;
+  total: string;
+  available: string;
+  locked: string;
+  averageOpenPrice: string;
+  leverage: number;
+  achievedProfits: string;
+  upl: string;
+  uplRate: string;
+  liqPx: string;
+  keepMarginRate: string;
+  marginRate: string;
+  cTime: string;
+  uTime: string;
+  markPrice: string;
+}
+⋮----
+export interface WSPositionSnapshotUMCBL extends WsBaseEvent<'snapshot'> {
+  arg: {
+    instType: 'umcbl';
+    channel: 'positions';
+    instId: string;
+  };
+  data: WsPositionSnapshotDataUMCBL[];
+}
+
+================
 File: .jshintrc
 ================
 {
@@ -4419,6 +3868,142 @@ function setWsClientEventListeners(
 // Simple promise to ensure we're subscribed before trying anything else
 ⋮----
 // Start trading
+
+================
+File: examples/auth/rest-private-rsa.md
+================
+# RSA Authentication with Bitget APIs in Node.js, JavaScript & TypeScript
+
+## Creating RSA Keys
+
+Officially, Bitget recommends downloading and running a key generator from their repo. Guidance for this can be found on the Bitget's website when trying to add a new RSA API key.
+
+However, openssl can be used to create the public & private key files using the following steps:
+
+```bash
+# Generate a private key with either 2048 or 4096 bit length
+openssl genrsa -out rsa-private-key.pem 4096
+
+# Generate a corresponding public key
+openssl rsa -in rsa-private-key.pem -pubout -out rsa-public-key.pem
+```
+
+## Using the RSA public key to get an API key from Bitget
+
+Once created, keep your **private key** completely secret! The **public** key needs to be provided to Bitget when creating new API credentials with the "Self-generated" option.
+
+Your public key should look something like this:
+
+```pem
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA1uWxxOXZUaX6AeZszf4x
+rBsU6axA5ipwxG7VPihVgssphDrrSOD0hZqnBmtF2bvT9ee1U0XOfMn+H+J5SH+1
+jgUpfioqH0L+KXl6wmLoPsadgfJz0SiQlFnKTkDXvMmecr6cdMHi2qNEx4CMc68C
+obvQ4Voz5qqpDwbohGtJh0p10PB//0Ejcoz0UwrTDq8BGeFmWa9pL/7h2vHtw+QU
+UxlnGmt98M8KkKqqvVicMK+IVtng/QlDw9ofG2kQcbBkPRaTjNI+8ULtCDH0sOkZ
+nT8PtGm4sEwmWH/dRWtUTWkMnUwCzuo/rWPb7WMprW2pKDTrLjUAr9M161t3Xa6W
+JO03K3NOxupy7ilululLY8d/WKWYDOZMvS5bPiPRUoZqlJneC0CT/2q1W6GfWzsT
+DCDTpgq/Ao7jTtnME9iadpwvFn0nMtNgJSrFDWPq8vKY9pRcEp/Na5qvIEOQIFnp
+/kIDPuMf+LZwO8lGFO3jnndY+62835rm7t6ZNM3NLoNCarvUCEasobgDJHw7x7c1
+fW/OxYtLrWGdMpsP0MewgGJZXcT7mvlBjQ+JWLoyIc5rYMIDw9RLWUPnrlRCxvPp
+sD9kDX7eaipdoik5yLyMaRvd16Vt9Bck/9pbSHazm41m/nd4KCZeGdsvrAA2beww
+zFWQQV9EX6/VLBgbnGTsMe0CAwEAAQ==
+-----END PUBLIC KEY-----
+```
+
+Submit this in the "Upload public key" form, shown when creating a new API key on Bitget and choosing the "self-generated"/RSA option.
+
+Note: the "-----BEGIN PUBLIC KEY-----" and "-----END PUBLIC KEY-----" header & footer can be included.
+
+After using the public key to create a new API key, you will be given an API Key such as the following:
+
+```
+SIHqWcDeRoj6gkOjLjQh1dnV1CD7IgwQTfL4LVa8wu04zNTYVSmJBIHsjQjgwWqt
+```
+
+This is the first piece, used as the "apiKey" in the [rest-private-rsa.ts](./rest-private-rsa.ts) example.
+
+## Using the RSA private key for RSA authentication with Bitget APIs in Node.js
+
+Your private key, if generated with the above steps, should look something like this (but with much more text):
+
+```pem
+-----BEGIN RSA PRIVATE KEY-----
+uayyi6wFTaNeG1/WCqhrowj2kCx8eB6NDZYl+OS9ZI9WC
+q/44iFERNuP0TXvQx8tgvSZXyu4/G618QzKh0Ii1uAATt2upa8dp1uGl2U7EqBE8
+p5y4pPzJuwvB3j6LQON20u2Wpbg8PQZACMfKym7lYDO+9MloK/gAQpyeYJzbw92C
+YE/ymq4JVjCMCQKCAQEA4/X0I9TO8vT0D0l83o693QA3C09uSZ6j9Obx5UrtDnA9
+sMkkRoe+R/vvIpVDzukMEEOmCuxbcdPoniVUKlTooK0Llo6JJ1l8CdFzQsOR97Pe
+csB6pxkLLH2qHx05xPBy4PyoB
+-----END RSA PRIVATE KEY-----
+```
+
+This is your secret, you should never share this with anyone, not even Bitget! Treat this like a password.
+
+As part of this authentication process, your private key is used to generate a signature (using `RSA-SHA256`). This SDK handles this process automatically for you. RSA authentication is automatically detected if the "api_secret" parameter contains the words "PRIVATE KEY", such as the header shown in the example above.
+
+From here, simply use the key provided by Bitget as the `api_key` parameter and your private key (with the header) as the `api_secret` parameter.
+
+Based on the above example, the following would prepare the main REST client using the above credentials:
+
+```typescript
+// Received after creating a new API key with a self-generated RSA public key on Bitget
+const API_KEY = 'bg_0866563123123123123f567e83e52fd';
+
+// The self-generated RSA private key, this is never directly given to Bitget, but used to generate a signature
+// Note: this MUST include the "BEGIN PRIVATE KEY" header so that the SDK understands this is RSA auth
+const rsaPrivateKey = `
+-----BEGIN PRIVATE KEY-----
+MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQC4kNgO71O0xkuH
+FjHnr5pimpEeiGPAtDTAeJoS55+kVrh3ThHsm0ARf36zimU
+gwrCWAnKqPlbqzWzs9mH9JvZWrEaOgWy
+8wMSJ21vtz1rRJhfaUUsOC1KLoWyvzqWW44zKaxoKSqCUMJqDbxIq7RjGlmc8KGJ
+scFWRSdfGEEpvqLlpTLoEtWHZP0pUUamSWrH/IgieFFhKaOPvmED24DJAlqSeEFw
+z7TW4dfWPRgjCRu4AAfgCtjb+3/7ONeQfx5XFvKFM7VNi/9sRh+alRqpzKrlI
+79bM1p/egrC4c8KUqrNk2s5c3HIU......THISISANEXAMPLE
+-----END PRIVATE KEY-----
+`;
+
+// This is set by you when registering your RSA API key in Bitget's website.
+const API_PASS = 'TestingRSA';
+
+const client = new RestClientV2({
+  apiKey: API_KEY,
+  apiSecret: rsaPrivateKey,
+  apiPass: API_PASS,
+});
+
+const clientV3 = new RestClientV3({
+  apiKey: API_KEY,
+  apiSecret: rsaPrivateKey,
+  apiPass: API_PASS,
+});
+```
+
+For a complete example, refer to the [rest-private-rsa.ts](./rest-private-rsa.ts) file on GitHub.
+
+================
+File: examples/auth/rest-private-rsa.ts
+================
+import { RestClientV2, RestClientV3 } from '../../src';
+⋮----
+// Import frmo NPM:
+// import { RestClientV2, RestClientV3 } from 'bitget-api';
+// or if you prefer require:
+// const { RestClientV2, RestClientV3 } = require('bitget-api');
+⋮----
+// Received after creating a new API key with a self-generated RSA public key on Bitget
+⋮----
+// The self-generated RSA private key, this is never directly given to Bitget, but used to generate a signature
+// Note: this MUST include the "BEGIN PRIVATE KEY" header so that the SDK understands this is RSA auth
+⋮----
+// This is set by you when registering your RSA API key in Bitget's website.
+⋮----
+// const wsClient = new WebsocketClientV2({
+//   apiKey: API_KEY,
+//   apiSecret: rsaPrivateKey,
+//   apiPass: API_PASS,
+// });
 
 ================
 File: examples/deprecated-V1-REST/rest-private-futures.ts
@@ -5836,688 +5421,6 @@ export interface GetConvertBGBHistoryRequestV2 {
 }
 
 ================
-File: src/types/request/v2/futures.ts
-================
-import { FuturesPlanTypeV2, FuturesProductTypeV2 } from '../shared.js';
-import { FuturesKlineInterval } from '../v1/futuresV1.js';
-⋮----
-export type FuturesKlineTypeV2 = 'MARKET' | 'MARK' | 'INDEX';
-⋮----
-export interface FuturesAccountBillRequestV2 {
-  productType: FuturesProductTypeV2;
-  symbol?: string;
-  coin?: string;
-  businessType?: string;
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-/**
- *
- * * Futures | Market
- *
- */
-⋮----
-export interface FuturesMergeDepthRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  precision?: 'scale0' | 'scale1' | 'scale2' | 'scale3';
-  limit?: '1' | '5' | '15' | '50' | 'max';
-}
-⋮----
-export interface FuturesRecentTradesRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  limit?: string;
-}
-⋮----
-export interface FuturesHistoricTradesRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  limit?: string;
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-}
-⋮----
-export interface FuturesCandlesRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  granularity: FuturesKlineInterval;
-  startTime?: string;
-  endTime?: string;
-  kLineType?: FuturesKlineTypeV2;
-  limit?: string;
-}
-⋮----
-/**
- *
- * * Futures | Account
- *
- */
-⋮----
-export interface FuturesSingleAccountRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin: string;
-}
-⋮----
-export interface FuturesInterestHistoryRequestV2 {
-  productType: 'USDT-FUTURES' | 'SUSDT-FUTURES';
-  coin?: string;
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-export interface FuturesOpenCountRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin: string;
-  openAmount: string;
-  openPrice: string;
-  leverage?: string;
-}
-⋮----
-export interface FuturesSetAutoMarginRequestV2 {
-  symbol: string;
-  autoMargin: 'on' | 'off';
-  marginCoin: string;
-  amount: string;
-  holdSide?: 'long' | 'short';
-}
-⋮----
-export interface FuturesSetLeverageRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin: string;
-  leverage: string;
-  holdSide?: 'long' | 'short';
-}
-⋮----
-export interface FuturesSetPositionMarginRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin: string;
-  holdSide: 'long' | 'short';
-  amount: string;
-}
-⋮----
-export interface FuturesSetMarginModeRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin: string;
-  marginMode: 'isolated' | 'crossed';
-}
-⋮----
-/**
- *
- * * Futures | Position
- *
- */
-⋮----
-export interface FuturesHistoricalPositionsRequestV2 {
-  symbol?: string;
-  productType?: FuturesProductTypeV2;
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-/**
- *
- * * Futures | Trade
- *
- */
-⋮----
-export interface FuturesPlaceOrderRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginMode: 'isolated' | 'crossed';
-  marginCoin: string;
-  size: string;
-  price?: string;
-  side: 'buy' | 'sell';
-  tradeSide?: 'open' | 'close';
-  orderType: 'limit' | 'market';
-  force?: 'ioc' | 'fok' | 'gtc' | 'post_only';
-  clientOid?: string;
-  reduceOnly?: 'YES' | 'NO';
-  presetStopSurplusPrice?: string;
-  presetStopLossPrice?: string;
-  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
-}
-⋮----
-export interface FuturesReversalOrderRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin: string;
-  size: string;
-  side?: 'buy' | 'sell';
-  tradeSide?: 'open' | 'close';
-  clientOid?: string;
-}
-⋮----
-interface FuturesBatchOrderItem {
-  size: string;
-  price?: string;
-  side: 'buy' | 'sell';
-  tradeSide?: 'open' | 'close';
-  orderType: 'limit' | 'market';
-  force?: 'ioc' | 'fok' | 'gtc' | 'post_only';
-  clientOid?: string;
-  reduceOnly?: 'YES' | 'NO';
-  presetStopSurplusPrice?: string;
-  presetStopLossPrice?: string;
-  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
-}
-⋮----
-export interface FuturesBatchOrderRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin: string;
-  marginMode: 'isolated' | 'crossed';
-  orderList: FuturesBatchOrderItem[];
-}
-⋮----
-export interface FuturesModifyOrderRequestV2 {
-  orderId?: string;
-  clientOid?: string;
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  newClientOid: string;
-  newSize?: string;
-  newPrice?: string;
-  newPresetStopSurplusPrice?: string;
-  newPresetStopLossPrice?: string;
-}
-⋮----
-export interface FuturesCancelOrderRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginCoin?: string;
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-interface FuturesBatchCancelOrderItem {
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-export interface FuturesBatchCancelOrderRequestV2 {
-  orderIdList?: FuturesBatchCancelOrderItem[];
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  marginCoin?: string;
-}
-⋮----
-export interface FuturesFlashClosePositionsRequestV2 {
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  holdSide?: 'long' | 'short';
-}
-⋮----
-export interface FuturesGetOrderRequestV2 {
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-export interface FuturesGetOrderFillsRequestV2 {
-  orderId?: string;
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-export interface FuturesGetHistoricalFillsRequestV2 {
-  orderId?: string;
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  startTime?: string;
-  endTime?: string;
-  idLessThan?: string;
-  limit?: string;
-}
-⋮----
-export interface FuturesGetOpenOrdersRequestV2 {
-  orderId?: string;
-  clientOid?: string;
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  status?: 'live' | 'partially_filled';
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-export type FuturesOrderSourceV2 =
-  | 'normal'
-  | 'market'
-  | 'profit_market'
-  | 'loss_market'
-  | 'Trader_delegate'
-  | 'trader_profit'
-  | 'trader_loss'
-  | 'reverse'
-  | 'trader_reverse'
-  | 'profit_limit'
-  | 'loss_limit'
-  | 'liquidation'
-  | 'delivery_close_long'
-  | 'delivery_close_short'
-  | 'pos_profit_limit'
-  | 'pos_profit_market'
-  | 'pos_loss_limit'
-  | 'pos_loss_market';
-⋮----
-export interface FuturesGetHistoryOrdersRequestV2 {
-  orderId?: string;
-  clientOid?: string;
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  idLessThan?: string;
-  orderSource?: FuturesOrderSourceV2;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-export interface FuturesCancelAllOrdersRequestV2 {
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  marginCoin?: string;
-  requestTime?: string;
-  receiveWindow?: string;
-}
-⋮----
-/**
- *
- * * Futures | Trigger Orders
- *
- */
-⋮----
-export type FuturesTriggerTypeV2 = 'fill_price' | 'mark_price';
-⋮----
-export type FuturesStpModeV2 =
-  | 'none'
-  | 'cancel_taker'
-  | 'cancel_maker'
-  | 'cancel_both';
-⋮----
-export interface FuturesTPSLOrderRequestV2 {
-  marginCoin: string;
-  productType: FuturesProductTypeV2;
-  symbol: string;
-  planType: FuturesPlanTypeV2;
-  triggerPrice: string;
-  triggerType?: FuturesTriggerTypeV2;
-  executePrice?: string;
-  holdSide: 'long' | 'short' | 'buy' | 'sell';
-  size: string;
-  rangeRate?: string;
-  clientOid?: string;
-  stpMode?: FuturesStpModeV2;
-}
-⋮----
-export type FuturesTriggerPriceTypeV2 =
-  | 'fill_price'
-  | 'mark_price'
-  | 'index_price';
-⋮----
-export interface FuturesPlanOrderRequestV2 {
-  planType: 'normal_plan' | 'track_plan';
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  marginMode: 'isolated' | 'crossed';
-  marginCoin: string;
-  size: string;
-  price?: string;
-  callbackRatio?: string;
-  triggerPrice: string;
-  triggerType: 'mark_price' | 'fill_price';
-  side: 'buy' | 'sell';
-  tradeSide?: 'open' | 'close';
-  orderType: 'limit' | 'market';
-  clientOid?: string;
-  reduceOnly?: 'YES' | 'NO';
-  stopSurplusTriggerPrice?: string;
-  stopSurplusExecutePrice?: string;
-  stopSurplusTriggerType?: FuturesTriggerPriceTypeV2;
-  stopLossTriggerPrice?: string;
-  stopLossExecutePrice?: string;
-  stopLossTriggerType?: FuturesTriggerPriceTypeV2;
-  stpMode?: FuturesStpModeV2;
-}
-⋮----
-export interface FuturesModifyTPSLOrderRequestV2 {
-  orderId?: string;
-  clientOid?: string;
-  marginCoin: string;
-  productType: FuturesProductTypeV2;
-  symbol: string;
-  triggerPrice: string;
-  triggerType?: 'fill_price' | 'mark_price';
-  executePrice?: string;
-  size: string;
-  rangeRate?: string;
-}
-⋮----
-export interface FuturesModifyPlanOrderRequestV2 {
-  planType: 'normal_plan' | 'track_plan';
-  orderId?: string;
-  clientOid?: string;
-  symbol: string;
-  productType: FuturesProductTypeV2;
-  newSize?: string;
-  newPrice?: string;
-  newCallbackRatio?: string;
-  newTriggerPrice?: string;
-  newTriggerType?: 'fill_price' | 'mark_price';
-  newStopSurplusTriggerPrice?: string;
-  newStopSurplusExecutePrice?: string;
-  newStopSurplusTriggerType?: FuturesTriggerPriceTypeV2;
-  newStopLossTriggerPrice?: string;
-  newStopLossExecutePrice?: string;
-  newStopLossTriggerType?: FuturesTriggerPriceTypeV2;
-}
-⋮----
-export interface FuturesGetPlanOrdersRequestV2 {
-  orderId?: string;
-  clientOid?: string;
-  symbol?: string;
-  planType: 'normal_plan' | 'track_plan' | 'profit_loss';
-  productType: FuturesProductTypeV2;
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-interface FuturesCancelPlanOrderItemV2 {
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-export type FuturesPlanOrderTypeV2 =
-  | 'normal_plan'
-  | 'profit_plan'
-  | 'loss_plan'
-  | 'pos_profit'
-  | 'pos_loss'
-  | 'moving_plan';
-⋮----
-export interface FuturesCancelPlanOrderRequestV2 {
-  orderIdList?: FuturesCancelPlanOrderItemV2[];
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  marginCoin?: string;
-  planType?: FuturesPlanOrderTypeV2;
-}
-⋮----
-export type FuturesPlanStatusV2 = 'executed' | 'fail_trigger' | 'cancelled';
-⋮----
-export interface FuturesGetHistoryPlanOrdersRequestV2 {
-  orderId?: string;
-  clientOid?: string;
-  planType: 'normal_plan' | 'track_plan' | 'profit_loss';
-  planStatus?: FuturesPlanStatusV2;
-  symbol?: string;
-  productType: FuturesProductTypeV2;
-  idLessThan?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-}
-⋮----
-/**
- *
- * * Futures | Union Margin
- *
- */
-⋮----
-export interface GetUnionTransferLimitsRequestV2 {
-  coin: string;
-}
-⋮----
-export interface UnionConvertRequestV2 {
-  coin: string;
-  amount: string;
-}
-
-================
-File: src/types/request/v3/strategy.ts
-================
-export interface PlaceStrategyOrderRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol: string;
-  clientOid?: string;
-  type?: 'tpsl';
-  tpslMode?: 'full' | 'partial';
-  qty: string;
-  posSide: 'long' | 'short';
-  tpTriggerBy?: 'market' | 'mark';
-  slTriggerBy?: 'market' | 'mark';
-  takeProfit?: string;
-  stopLoss?: string;
-  tpOrderType?: 'limit' | 'market';
-  slOrderType?: 'limit' | 'market';
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-}
-⋮----
-export interface ModifyStrategyOrderRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-  qty: string;
-  tpTriggerBy?: 'market' | 'mark';
-  slTriggerBy?: 'market' | 'mark';
-  takeProfit?: string;
-  stopLoss?: string;
-  tpOrderType?: 'limit' | 'market';
-  slOrderType?: 'limit' | 'market';
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
-}
-⋮----
-export interface CancelStrategyOrderRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-export interface GetUnfilledStrategyOrdersRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  type?: 'tpsl';
-}
-⋮----
-export interface GetHistoryStrategyOrdersRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  type?: 'tpsl';
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  cursor?: string;
-}
-
-================
-File: src/types/request/v3/trade.ts
-================
-export interface BatchModifyOrderRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-  qty?: string;
-  price?: string;
-  autoCancel?: 'yes' | 'no';
-}
-⋮----
-export interface CancelAllOrdersRequestV3 {
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  symbol?: string;
-}
-⋮----
-export interface CancelBatchOrdersRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  symbol: string;
-}
-⋮----
-export interface CloseAllPositionsRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol?: string;
-  posSide?: 'long' | 'short';
-}
-⋮----
-export interface CancelOrderRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-export interface GetMaxOpenAvailableRequestV3 {
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  symbol: string;
-  orderType: 'limit' | 'market';
-  side: 'buy' | 'sell';
-  price?: string;
-  size?: string;
-}
-⋮----
-export interface GetOrderInfoRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-export interface GetFillsRequestV3 {
-  orderId?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetUnfilledOrdersRequestV3 {
-  category?:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  symbol?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetHistoryOrdersRequestV3 {
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetPositionHistoryRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetCurrentPositionRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol?: string;
-  posSide?: 'long' | 'short';
-}
-⋮----
-export interface ModifyOrderRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-  qty?: string;
-  price?: string;
-  autoCancel?: 'yes' | 'no';
-}
-⋮----
-export interface PlaceBatchOrdersRequestV3 {
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  symbol: string;
-  qty: string;
-  price?: string;
-  side: 'buy' | 'sell';
-  orderType: 'limit' | 'market';
-  timeInForce?: 'ioc' | 'fok' | 'gtc' | 'post_only';
-  posSide?: 'long' | 'short';
-  clientOid?: string;
-  reduceOnly?: 'yes' | 'no';
-}
-⋮----
-export interface PlaceOrderRequestV3 {
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  symbol: string;
-  qty: string;
-  price?: string;
-  side: 'buy' | 'sell';
-  orderType: 'limit' | 'market';
-  timeInForce?: 'ioc' | 'fok' | 'gtc' | 'post_only';
-  posSide?: 'long' | 'short';
-  clientOid?: string;
-  reduceOnly?: 'yes' | 'no';
-  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
-  takeProfitPrice?: string;
-  stopLossPrice?: string;
-  takeProfitTriggerType?: 'mark_price' | 'last_price';
-  stopLossTriggerType?: 'mark_price' | 'last_price';
-}
-⋮----
-export interface CountdownCancelAllRequestV3 {
-  countdown: string; // seconds until auto-cancel (5-60, or 0 to disable)
-}
-⋮----
-countdown: string; // seconds until auto-cancel (5-60, or 0 to disable)
-
-================
 File: src/types/response/v1/futures.ts
 ================
 import {
@@ -6602,102 +5505,428 @@ export interface FuturesPosition {
 }
 
 ================
-File: src/types/response/v3/loan.ts
+File: src/types/response/v3/public.ts
 ================
-export interface LoanTransfersV3 {
-  coin: string;
-  transfered: string;
-  userId: string;
-}
-⋮----
-export interface LoanSymbolSettingV3 {
-  symbol: string;
-  leverage: string;
-}
-⋮----
-export interface LoanSymbolsV3 {
-  productId: string;
-  spotSymbols: string[];
-  usdtContractLeverage: string;
-  coinContractLeverage: string;
-  usdcContractLeverage: string;
-  usdtContractSymbols: LoanSymbolSettingV3[];
-  coinContractSymbols: LoanSymbolSettingV3[];
-  usdcContractSymbols: LoanSymbolSettingV3[];
-}
-⋮----
-export interface RepaidHistoryItemV3 {
-  repayOrderId: string;
-  businessType: 'normal' | 'liquidation';
-  repayType: 'all' | 'part';
-  repaidTime: string;
-  coin: string;
-  repayAmount: string;
-  repayInterest: string;
-}
-⋮----
-export interface LoanProductInfoV3 {
-  productId: string;
-  leverage: string;
-  supportUsdtContract: 'YES' | 'NO';
-  supportCoinContract: 'YES' | 'NO';
-  supportUsdcContract: 'YES' | 'NO';
-  transferLine: string;
-  spotBuyLine: string;
-  usdtContractOpenLine: string;
-  coinContractOpenLine: string;
-  usdcContractOpenLine: string;
-  liquidationLine: string;
-  stopLiquidationLine: string;
-}
-⋮----
-export interface LoanOrderV3 {
-  orderId: string;
-  orderProductId: string;
-  uid: string;
-  loanTime: string;
-  loanCoin: string;
-  loanAmount: string;
-  unpaidAmount: string;
-  unpaidInterest: string;
-  repaidAmount: string;
-  repaidInterest: string;
-  reserve: string;
-  status: 'not_paid_off' | 'paid_off';
-}
-⋮----
-export interface CoinInfoV3 {
-  coin: string;
-  convertRatio: string;
-  maxConvertValue: string;
-}
-⋮----
-export interface BindUidResponseV3 {
-  riskUnitId: string;
-  uid: string;
-  operate: 'bind' | 'unbind';
-}
-⋮----
-export interface UnpaidInfoV3 {
-  coin: string;
-  unpaidQty: string;
-  unpaidInterest: string;
-}
-⋮----
-export interface BalanceInfoV3 {
-  coin: string;
+export interface PublicFillV3 {
+  execId: string;
   price: string;
-  amount: string;
-  convertedUsdtAmount: string;
+  size: string;
+  side: 'sell' | 'buy';
+  ts: string;
 }
 ⋮----
-export interface LTVConvertResponseV3 {
-  ltv: string;
-  subAccountUids: string[];
-  unpaidUsdtAmount: string;
-  usdtBalance: string;
-  unpaidInfo: UnpaidInfoV3[];
-  balanceInfo: BalanceInfoV3[];
+export interface CandlestickV3 extends Array<string> {
+  0: string; // timestamp
+  1: string; // open price
+  2: string; // high price
+  3: string; // low price
+  4: string; // close price
+  5: string; // volume
+  6: string; // turnover
+}
+⋮----
+0: string; // timestamp
+1: string; // open price
+2: string; // high price
+3: string; // low price
+4: string; // close price
+5: string; // volume
+6: string; // turnover
+⋮----
+export interface ContractOiV3 {
+  symbol: string;
+  notionalValue: string;
+  totalNotionalValue: string;
+}
+⋮----
+export interface CurrentFundingRateV3 {
+  symbol: string;
+  fundingRate: string;
+  fundingRateInterval: string;
+  nextUpdate: string;
+  minFundingRate: string;
+  maxFundingRate: string;
+}
+⋮----
+export interface DiscountRateTierV3 {
+  tierStartValue: string;
+  discountRate: string;
+}
+⋮----
+export interface DiscountRateV3 {
+  coin: string;
+  list: DiscountRateTierV3[];
+}
+⋮----
+export interface HistoryFundingRateV3 {
+  symbol: string;
+  fundingRate: string;
+  fundingRateTimestamp: string;
+}
+⋮----
+export interface MarginLoanV3 {
+  dailyInterest: string;
+  annualInterest: string;
+  limit: string;
+}
+⋮----
+export interface OpenInterestItemV3 {
+  symbol: string;
+  openInterest: string;
+}
+⋮----
+export interface OpenInterestV3 {
+  list: OpenInterestItemV3[];
+  ts: string;
+}
+⋮----
+export interface PositionTierV3 {
+  tier: string;
+  minTierValue: string;
+  maxTierValue: string;
+  leverage: string;
+  mmr: string;
+}
+⋮----
+export interface RiskReserveRecordV3 {
+  balance: string;
+  amount: string;
+  ts: string;
+}
+⋮----
+export interface RiskReserveV3 {
+  coin: string;
+  riskReserveRecords: RiskReserveRecordV3[];
+}
+⋮----
+export interface InstrumentV3 {
+  symbol: string;
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  baseCoin: string;
+  quoteCoin: string;
+  buyLimitPriceRatio: string;
+  sellLimitPriceRatio: string;
+  feeRateUpRatio: string;
+  minOrderQty: string;
+  maxOrderQty: string;
+  maxMarketOrderQty: string;
+  pricePrecision: string;
+  quantityPrecision: string;
+  quotePrecision: string;
+  minOrderAmount: string;
+  maxSymbolOrderNum: string;
+  maxProductOrderNum: string;
+  status:
+    | 'listed'
+    | 'online'
+    | 'limit_open'
+    | 'limit_close'
+    | 'offline'
+    | 'restrictedAPI';
+  offTime: string;
+  limitOpenTime: string;
+  maintainTime: string;
+  areaSymbol?: string;
+
+  // Futures specific fields
+  makerFeeRate?: string;
+  takerFeeRate?: string;
+  openCostUpRatio?: string;
+  priceMultiplier?: string;
+  quantityMultiplier?: string;
+  symbolType?: 'perpetual' | 'delivery';
+  maxPositionNum?: string;
+  deliveryTime?: string;
+  deliveryStartTime?: string;
+  deliveryPeriod?: string;
+  launchTime?: string;
+  fundInterval?: string;
+  minLeverage?: string;
+  maxLeverage?: string;
+
+  // Margin specific fields
+  isIsolatedBaseBorrowable?: 'YES' | 'NO';
+  isIsolatedQuotedBorrowable?: 'YES' | 'NO';
+  warningRiskRatio?: string;
+  liquidationRiskRatio?: string;
+  maxCrossedLeverage?: string;
+  maxIsolatedLeverage?: string;
+  userMinBorrow?: string;
+}
+⋮----
+// Futures specific fields
+⋮----
+// Margin specific fields
+⋮----
+export interface OrderBookV3 {
+  a: string[][]; // asks - [price, size]
+  b: string[][]; // bids - [price, size]
+  ts: string;
+}
+⋮----
+a: string[][]; // asks - [price, size]
+b: string[][]; // bids - [price, size]
+⋮----
+export interface TickerV3 {
+  category: 'SPOT' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  lastPrice: string;
+  openPrice24h: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  ask1Price: string;
+  bid1Price: string;
+  bid1Size: string;
+  ask1Size: string;
+  price24hPcnt: string;
+  volume24h: string;
+  turnover24h: string;
+
+  // Futures specific fields
+  indexPrice?: string;
+  markPrice?: string;
+  fundingRate?: string;
+  openInterest?: string;
+  deliveryStartTime?: string;
+  deliveryTime?: string;
+  deliveryStatus?: string;
+}
+⋮----
+// Futures specific fields
+⋮----
+export interface ProofOfReservesV3 {
+  merkleRootHash: string;
+  totalReserveRatio: string;
+  list: {
+    coin: string;
+    userAssets: string;
+    platformAssets: string;
+    reserveRatio: string;
+  }[];
+}
+
+================
+File: src/types/response/v3/trade.ts
+================
+export interface BatchModifyOrderResponseV3 {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface CancelAllOrdersResponseV3 {
+  list: {
+    orderId: string;
+    clientOid: string;
+    code: string;
+    msg: string;
+  }[];
+}
+⋮----
+export interface CancelBatchOrdersResponseV3 {
+  orderId: string;
+  clientOid: string;
+  code?: string;
+  msg?: string;
+}
+⋮----
+export interface CloseAllPositionsResponseV3 {
+  list: {
+    orderId: string;
+    clientOid: string;
+    code: string;
+    msg: string;
+  }[];
+}
+⋮----
+export interface CancelOrderResponseV3 {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface GetMaxOpenAvailableResponseV3 {
+  available: string;
+  maxOpen: string;
+  buyOpenCost: string;
+  sellOpenCost: string;
+  maxBuyOpen: string;
+  maxSellOpen: string;
+}
+⋮----
+export interface FeeDetailV3 {
+  feeCoin: string;
+  fee: string;
+}
+⋮----
+export interface OrderInfoV3 {
+  orderId: string;
+  clientOid: string;
+  category: string;
+  symbol: string;
+  orderType: string;
+  side: string;
+  price: string;
+  qty: string;
+  amount: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  avgPrice: string;
+  timeInForce: string;
+  orderStatus: string;
+  posSide: string;
+  holdMode: string;
+  reduceOnly: string;
+  feeDetail: FeeDetailV3[];
+  cancelReason: string;
+  execType: string;
+  stpMode?: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+export interface FillV3 {
+  execId: string;
+  orderId: string;
+  category: string;
+  symbol: string;
+  orderType: string;
+  side: string;
+  execPrice: string;
+  execQty: string;
+  execValue: string;
+  tradeScope: string;
+  feeDetail: FeeDetailV3[];
+  execPnl?: string;
+  tradeSide?: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+export interface UnfilledOrderV3 {
+  orderId: string;
+  clientOid: string;
+  category: string;
+  symbol: string;
+  orderType: string;
+  side: string;
+  price: string;
+  qty: string;
+  amount: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  avgPrice: string;
+  timeInForce: string;
+  orderStatus: string;
+  posSide: string;
+  holdMode: string;
+  reduceOnly: string;
+  feeDetail: FeeDetailV3[];
+  stpMode?: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+export interface HistoryOrderV3 {
+  orderId: string;
+  clientOid: string;
+  category: string;
+  symbol: string;
+  orderType: string;
+  side: string;
+  price: string;
+  qty: string;
+  amount: string;
+  cumExecQty: string;
+  cumExecValue: string;
+  avgPrice: string;
+  timeInForce: string;
+  orderStatus: string;
+  posSide: string;
+  holdMode: string;
+  reduceOnly: string;
+  feeDetail: FeeDetailV3[];
+  cancelReason: string;
+  execType: string;
+  stpMode?: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+export interface PositionHistoryV3 {
+  positionId: string;
+  category: string;
+  symbol: string;
+  marginCoin: string;
+  holdMode: string;
+  posSide: string;
+  marginMode: string;
+  openPriceAvg: string;
+  closePriceAvg: string;
+  openTotalPos: string;
+  closeTotalPos: string;
+  cumRealisedPnl: string;
+  netProfit: string;
+  totalFunding: string;
+  openFeeTotal: string;
+  closeFeeTotal: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+export interface CurrentPositionV3 {
+  category: string;
+  symbol: string;
+  marginCoin: string;
+  holdMode: string;
+  posSide: string;
+  marginMode: string;
+  positionBalance: string;
+  available: string;
+  frozen: string;
+  total: string;
+  leverage: string;
+  curRealisedPnl: string;
+  avgPrice: string;
+  positionStatus: string;
+  unrealisedPnl: string;
+  liquidationPrice: string;
+  mmr: string;
+  profitRate: string;
+  markPrice: string;
+  breakEvenPrice: string;
+  totalFunding: string;
+  openFeeTotal: string;
+  closeFeeTotal: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+export interface ModifyOrderResponseV3 {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface PlaceBatchOrdersResponseV3 {
+  orderId: string;
+  clientOid: string;
+  code?: string;
+  msg?: string;
+}
+⋮----
+export interface PlaceOrderResponseV3 {
+  orderId: string;
+  clientOid: string;
+}
+⋮----
+export interface PositionAdlRankV3 {
+  symbol: string;
+  marginCoin: string;
+  adlRank: string;
+  holdSide: 'long' | 'short';
 }
 
 ================
@@ -6708,100 +5937,6 @@ export interface WSAPIPlaceOrderResponseV3 {
   orderId: string;
   clientOid: string;
   cTime: string;
-}
-
-================
-File: src/types/websockets/ws-events.ts
-================
-export interface MessageEventLike {
-  target: WebSocket;
-  type: 'message';
-  data: string;
-}
-⋮----
-export function isMessageEvent(msg: unknown): msg is MessageEventLike
-⋮----
-export interface WsBaseEvent<TAction = 'snapshot' | string, TData = unknown> {
-  action: TAction;
-  arg: unknown;
-  data: TData[];
-}
-⋮----
-export interface WsSnapshotChannelEvent extends WsBaseEvent<'snapshot'> {
-  arg: {
-    instType: string;
-    channel: string;
-    instId: string;
-  };
-}
-⋮----
-export interface WsSnapshotAccountEvent extends WsBaseEvent<'snapshot'> {
-  arg: {
-    instType: string;
-    channel: 'account';
-    instId: string;
-  };
-}
-⋮----
-export interface WsSnapshotPositionsEvent extends WsBaseEvent<'snapshot'> {
-  arg: {
-    instType: string;
-    channel: 'positions';
-    instId: string;
-  };
-}
-⋮----
-export interface WsAccountSnapshotDataUMCBL {
-  marginCoin: string;
-  locked: string;
-  available: string;
-  maxOpenPosAvailable: string;
-  maxTransferOut: string;
-  equity: string;
-  usdtEquity: string;
-}
-⋮----
-export interface WsAccountSnapshotUMCBL extends WsBaseEvent<'snapshot'> {
-  arg: {
-    instType: 'umcbl';
-    channel: 'account';
-    instId: string;
-  };
-  data: WsAccountSnapshotDataUMCBL[];
-}
-⋮----
-export interface WsPositionSnapshotDataUMCBL {
-  posId: string;
-  instId: string;
-  instName: string;
-  marginCoin: string;
-  margin: string;
-  marginMode: string;
-  holdSide: string;
-  holdMode: string;
-  total: string;
-  available: string;
-  locked: string;
-  averageOpenPrice: string;
-  leverage: number;
-  achievedProfits: string;
-  upl: string;
-  uplRate: string;
-  liqPx: string;
-  keepMarginRate: string;
-  marginRate: string;
-  cTime: string;
-  uTime: string;
-  markPrice: string;
-}
-⋮----
-export interface WSPositionSnapshotUMCBL extends WsBaseEvent<'snapshot'> {
-  arg: {
-    instType: 'umcbl';
-    channel: 'positions';
-    instId: string;
-  };
-  data: WsPositionSnapshotDataUMCBL[];
 }
 
 ================
@@ -7797,19 +6932,13 @@ getHistoricPlanOrders(params: GetHistoricPlanOrdersParams): Promise<
 ================
 File: webpack/webpack.config.js
 ================
-function generateConfig(name) {
-⋮----
-path: path.resolve(__dirname, '../dist'),
+function generateConfig(name)
 ⋮----
 // Add '.ts' and '.tsx' as resolvable extensions.
 ⋮----
 // All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
 ⋮----
 // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-⋮----
-new BundleAnalyzerPlugin({
-⋮----
-module.exports = generateConfig('bitgetapi');
 
 ================
 File: .nvmrc
@@ -8237,539 +7366,203 @@ File: src/constants/enum.ts
 /** Parameter verification exception margin mode == FIXED */
 
 ================
-File: src/types/response/v3/public.ts
+File: src/types/request/v2/broker.ts
 ================
-export interface PublicFillV3 {
-  execId: string;
-  price: string;
-  size: string;
-  side: 'sell' | 'buy';
-  ts: string;
+/**
+ *
+ * * Broker | Subaccount
+ *
+ */
+⋮----
+export interface GetSubAccountsRequestV2 {
+  limit?: string;
+  idLessThan?: string;
+  status?: 'normal' | 'freeze' | 'del';
+  startTime?: string;
+  endTime?: string;
 }
 ⋮----
-export interface CandlestickV3 extends Array<string> {
-  0: string; // timestamp
-  1: string; // open price
-  2: string; // high price
-  3: string; // low price
-  4: string; // close price
-  5: string; // volume
-  6: string; // turnover
+export type SubAccountPermissionV2 =
+  | 'withdraw'
+  | 'transfer'
+  | 'spot_trade'
+  | 'contract_trade'
+  | 'read'
+  | 'deposit'
+  | 'margin_trade';
+⋮----
+export type SubAccountLanguageV2 =
+  | 'en_US'
+  | 'zh_CN'
+  | 'ja_JP'
+  | 'vi_VN'
+  | 'zh_TW'
+  | 'ru_RU'
+  | 'es_ES'
+  | 'tr_TR'
+  | 'fr_FR'
+  | 'de_DE'
+  | 'pt_PT'
+  | 'th_TH';
+⋮----
+export type SubAccountStatusV2 = 'normal' | 'freeze';
+⋮----
+export interface ModifySubRequestV2 {
+  subUid: string;
+  permList: SubAccountPermissionV2[];
+  status: SubAccountStatusV2;
+  language?: SubAccountLanguageV2;
 }
 ⋮----
-0: string; // timestamp
-1: string; // open price
-2: string; // high price
-3: string; // low price
-4: string; // close price
-5: string; // volume
-6: string; // turnover
-⋮----
-export interface ContractOiV3 {
-  symbol: string;
-  notionalValue: string;
-  totalNotionalValue: string;
-}
-⋮----
-export interface CurrentFundingRateV3 {
-  symbol: string;
-  fundingRate: string;
-  fundingRateInterval: string;
-  nextUpdate: string;
-  minFundingRate: string;
-  maxFundingRate: string;
-}
-⋮----
-export interface DiscountRateTierV3 {
-  tierStartValue: string;
-  discountRate: string;
-}
-⋮----
-export interface DiscountRateV3 {
+export interface SubWithdrawalRequestV2 {
+  subUid: string;
   coin: string;
-  list: DiscountRateTierV3[];
-}
-⋮----
-export interface HistoryFundingRateV3 {
-  symbol: string;
-  fundingRate: string;
-  fundingRateTimestamp: string;
-}
-⋮----
-export interface MarginLoanV3 {
-  dailyInterest: string;
-  annualInterest: string;
-  limit: string;
-}
-⋮----
-export interface OpenInterestItemV3 {
-  symbol: string;
-  openInterest: string;
-}
-⋮----
-export interface OpenInterestV3 {
-  list: OpenInterestItemV3[];
-  ts: string;
-}
-⋮----
-export interface PositionTierV3 {
-  tier: string;
-  minTierValue: string;
-  maxTierValue: string;
-  leverage: string;
-  mmr: string;
-}
-⋮----
-export interface RiskReserveRecordV3 {
-  balance: string;
+  dest: 'on_chain' | 'internal_transfer';
+  chain?: string;
+  address: string;
   amount: string;
-  ts: string;
-}
-⋮----
-export interface RiskReserveV3 {
-  coin: string;
-  riskReserveRecords: RiskReserveRecordV3[];
-}
-⋮----
-export interface InstrumentV3 {
-  symbol: string;
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  baseCoin: string;
-  quoteCoin: string;
-  buyLimitPriceRatio: string;
-  sellLimitPriceRatio: string;
-  feeRateUpRatio: string;
-  minOrderQty: string;
-  maxOrderQty: string;
-  maxMarketOrderQty: string;
-  pricePrecision: string;
-  quantityPrecision: string;
-  quotePrecision: string;
-  minOrderAmount: string;
-  maxSymbolOrderNum: string;
-  maxProductOrderNum: string;
-  status: 'listed' | 'online' | 'limit_open' | 'offline' | 'restrictedAPI';
-  offTime: string;
-  limitOpenTime: string;
-  maintainTime: string;
-  areaSymbol?: string;
-
-  // Futures specific fields
-  makerFeeRate?: string;
-  takerFeeRate?: string;
-  openCostUpRatio?: string;
-  priceMultiplier?: string;
-  quantityMultiplier?: string;
-  symbolType?: 'perpetual' | 'delivery';
-  maxPositionNum?: string;
-  deliveryTime?: string;
-  deliveryStartTime?: string;
-  deliveryPeriod?: string;
-  launchTime?: string;
-  fundInterval?: string;
-  minLeverage?: string;
-  maxLeverage?: string;
-
-  // Margin specific fields
-  isIsolatedBaseBorrowable?: 'YES' | 'NO';
-  isIsolatedQuotedBorrowable?: 'YES' | 'NO';
-  warningRiskRatio?: string;
-  liquidationRiskRatio?: string;
-  maxCrossedLeverage?: string;
-  maxIsolatedLeverage?: string;
-  userMinBorrow?: string;
-}
-⋮----
-// Futures specific fields
-⋮----
-// Margin specific fields
-⋮----
-export interface OrderBookV3 {
-  a: string[][]; // asks - [price, size]
-  b: string[][]; // bids - [price, size]
-  ts: string;
-}
-⋮----
-a: string[][]; // asks - [price, size]
-b: string[][]; // bids - [price, size]
-⋮----
-export interface TickerV3 {
-  category: 'SPOT' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol: string;
-  lastPrice: string;
-  openPrice24h: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  ask1Price: string;
-  bid1Price: string;
-  bid1Size: string;
-  ask1Size: string;
-  price24hPcnt: string;
-  volume24h: string;
-  turnover24h: string;
-
-  // Futures specific fields
-  indexPrice?: string;
-  markPrice?: string;
-  fundingRate?: string;
-  openInterest?: string;
-  deliveryStartTime?: string;
-  deliveryTime?: string;
-  deliveryStatus?: string;
-}
-⋮----
-// Futures specific fields
-⋮----
-export interface ProofOfReservesV3 {
-  merkleRootHash: string;
-  totalReserveRatio: string;
-  list: {
-    coin: string;
-    userAssets: string;
-    platformAssets: string;
-    reserveRatio: string;
-  }[];
-}
-
-================
-File: src/types/response/v3/strategy.ts
-================
-export interface PlaceStrategyOrderResponseV3 {
-  orderId: string;
-  clientOid: string;
-}
-⋮----
-export interface ModifyStrategyOrderResponseV3 {
-  orderId: string;
-  clientOid: string;
-}
-⋮----
-export interface StrategyOrderV3 {
-  orderId: string;
-  clientOid: string;
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol: string;
-  qty: string;
-  posSide: 'long' | 'short';
-  tpTriggerBy: 'market' | 'mark';
-  slTriggerBy: 'market' | 'mark';
-  takeProfit: string;
-  stopLoss: string;
-  tpOrderType: 'limit' | 'market';
-  slOrderType: 'limit' | 'market';
-  tpLimitPrice: string;
-  slLimitPrice: string;
-  createdTime: string;
-  updatedTime: string;
-}
-
-================
-File: src/types/websockets/ws-api-request.ts
-================
-export interface WSAPIPlaceOrderRequestV3 {
-  symbol: string;
-  orderType: 'limit' | 'market';
-  qty: string;
-  price?: string;
-  side: 'buy' | 'sell';
-  posSide?: 'long' | 'short';
-  timeInForce?: 'gtc' | 'ioc' | 'fok' | 'post_only';
-  reduceOnly?: 'YES' | 'NO'; // Note: reduceOnly is not supported for batch place WS API. Might be supported starting late Q4 2025, but not supported yet.
+  tag?: string;
   clientOid?: string;
-  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
-  tpTriggerBy?: 'market' | 'mark';
-  slTriggerBy?: 'market' | 'mark';
-  takeProfit?: string;
-  stopLoss?: string;
-  tpOrderType?: 'limit' | 'market';
-  slOrderType?: 'limit' | 'market';
-  tpLimitPrice?: string;
-  slLimitPrice?: string;
 }
 ⋮----
-reduceOnly?: 'YES' | 'NO'; // Note: reduceOnly is not supported for batch place WS API. Might be supported starting late Q4 2025, but not supported yet.
-
-================
-File: src/websocket-api-client.ts
-================
-import { CancelOrderRequestV3 } from './types/request/v3/trade.js';
-import { CancelOrderResponseV3 } from './types/response/v3/trade.js';
-import { WSAPIResponse } from './types/websockets/ws-api.js';
-import { WSAPIPlaceOrderRequestV3 } from './types/websockets/ws-api-request.js';
-import { WSAPIPlaceOrderResponseV3 } from './types/websockets/ws-api-response.js';
-import {
-  BitgetInstTypeV3,
-  WSClientConfigurableOptions,
-} from './types/websockets/ws-general.js';
-import { DefaultLogger } from './util/logger.js';
-import { WS_KEY_MAP } from './util/websocket-util.js';
-import { WebsocketClientV3 } from './websocket-client-v3.js';
+export interface SubDepositRecordsRequestV2 {
+  orderId?: string;
+  userId?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  idLessThan?: string;
+}
 ⋮----
-/**
- * Configurable options specific to only the REST-like WebsocketAPIClient
- */
-export interface WSAPIClientConfigurableOptions {
-  /**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-  attachEventListeners: boolean;
+export interface SubWithdrawalRecordsRequestV2 {
+  orderId?: string;
+  userId?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  idLessThan?: string;
 }
 ⋮----
 /**
-   * Default: true
-   *
-   * Attach default event listeners, which will console log any high level
-   * events (opened/reconnecting/reconnected/etc).
-   *
-   * If you disable this, you should set your own event listeners
-   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
-   */
-⋮----
-/**
- * This is a minimal Websocket API wrapper around the WebsocketClient.
  *
- * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
- * may find the below methods slightly more intuitive.
+ * * Broker | Subaccount
  *
- * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
- * https://github.com/tiagosiebler/bitget-api/blob/master/examples/V3/ws-api-trade-raw.ts
  */
-export class WebsocketAPIClient
 ⋮----
-constructor(
-    options?: WSClientConfigurableOptions &
-      Partial<WSAPIClientConfigurableOptions>,
-    logger?: DefaultLogger,
-)
-⋮----
-public getWSClient(): WebsocketClientV3
-⋮----
-public setTimeOffsetMs(newOffset: number): void
-⋮----
-/*
-   * Bitget WebSocket API Methods
-   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel
-   */
-⋮----
-/**
-   * Submit a new order
-   *
-   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel
-   *
-   * @returns
-   */
-submitNewOrder(
-    category: BitgetInstTypeV3,
-    params: WSAPIPlaceOrderRequestV3,
-): Promise<WSAPIResponse<[WSAPIPlaceOrderResponseV3], 'place-order'>>
-⋮----
-/**
-   * Submit a new order
-   *
-   * https://www.bitget.com/api-doc/uta/websocket/private/Batch-Place-Order-Channel
-   *
-   * @returns
-   */
-placeBatchOrders(
-    category: BitgetInstTypeV3,
-    params: WSAPIPlaceOrderRequestV3[],
-): Promise<WSAPIResponse<WSAPIPlaceOrderResponseV3[], 'batch-place'>>
-⋮----
-/*
-   * Bitget WebSocket API Methods
-   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel
-   */
-⋮----
-/**
-   * Cancel Order
-   *
-   * https://www.bitget.com/api-doc/uta/websocket/private/Cancel-Order-Channel
-   *
-   * @returns
-   */
-cancelOrder(
-    category: BitgetInstTypeV3,
-    params: CancelOrderRequestV3,
-): Promise<WSAPIResponse<[CancelOrderResponseV3], 'cancel-order'>>
-⋮----
-/**
-   * Batch Cancel Order
-   *
-   * https://www.bitget.com/api-doc/uta/websocket/private/Batch-Cancel-Order-Channel
-   *
-   * @returns
-   */
-cancelBatchOrders(
-    category: BitgetInstTypeV3,
-    params: CancelOrderRequestV3[],
-): Promise<WSAPIResponse<CancelOrderResponseV3[], 'batch-cancel'>>
-⋮----
-/**
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   * Private methods for handling some of the convenience/automation provided by the WS API Client
-   *
-   *
-   *
-   *
-   *
-   *
-   *
-   */
-⋮----
-private setupDefaultEventListeners()
-⋮----
-/**
-       * General event handlers for monitoring the WebsocketClient
-       */
-
-================
-File: .gitignore
-================
-!.gitkeep
-.DS_STORE
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-lerna-debug.log*
-report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-pids
-*.pid
-*.seed
-*.pid.lock
-node_modules/
-.npm
-.eslintcache
-.node_repl_history
-*.tgz
-.yarn-integrity
-.env
-.env.test
-.cache
-lib
-bundleReport.html
-.history/
-tiagoSpot.ts
-restClientRegex.ts
-localtest.sh
-privaterepotracker
-testfile.ts
-dist
-repomix.sh
-coverage
-
-================
-File: examples/README.md
-================
-# Examples
-
-These samples can be executed using `ts-node`:
-
-```
-ts-node ./examples/rest-spot-public.ts
-```
-
-Samples that require authentication can be edited directly but also support environmental variables. E.g. on mac/unix:
-
-```
-API_KEY_COM='yourkeyhere' API_SECRET_COM='yoursecrethere' API_PASS_COM='yourapipasshere' ts-node examples/rest-trade-futures.ts
-```
-
-They can also be converted to JavaScript by changing the imports to require & removing any type annotations.
-
-## V3 / Unified Trading Account (UTA)
-
-These newer examples are for Bitget's V3 APIs and WebSockets. They can be found in the examples/V3 folder.
-
-Refer to the V3 / UTA API documentation for more information on the V3 APIs:
-https://www.bitget.com/api-doc/uta/intro
-
-These APIs require your account to be upgraded to the Unified Trading Account, if you plan on using the account-level REST APIs and WebSockets. Once upgraded, the V2 APIs are no longer available to you, unless you revert back to Classic Account mode.
-
-### WebSocket API (WS API)
-
-The V3/UTA API introduces order placement via a persisted WebSocket connection. This Bitget Node.js, JavaScript & TypeScript SDK supports Bitget's full V3 API offering, including the WebSocket API.
-
-There are two approaches to placing orders via the Bitget WebSocket APIs
-
-#### WebsocketAPIClient (recommended)
-
-This integration looks & feels like a REST API client, but uses WebSockets, via the WebsocketClient's sendWSAPIRequest method. It returns promises and has end to end types.
-
-This is the recommended approach to easily start sending orders via an automatically persisted WebSocket connection. A simple example is below, but for a more thorough example, check the example here: [./V3/ws-api-client-trade.ts](./V3/ws-api-client-trade.ts)
-
-```typescript
-import { WebsocketAPIClient } from 'bitget-api';
-// or if you prefer require:
-// const { WebsocketAPIClient } = require("bitget-api");
-
-// Make an instance of the WS API Client class with your API keys
-const wsClient = new WebsocketAPIClient({
-  apiKey: API_KEY,
-  apiSecret: API_SECRET,
-  apiPass: API_PASS,
-
-  // Whether to use the demo trading wss connection
-  // demoTrading: true,
-});
-
-async function start() {
-  // Start using it like a REST API. All actions are sent via a persisted WebSocket connection.
-
-  /**
-   * Place Order
-   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel#request-parameters
-   */
-  try {
-    const res = await wsClient.submitNewOrder('spot', {
-      orderType: 'limit',
-      price: '100',
-      qty: '0.1',
-      side: 'buy',
-      symbol: 'BTCUSDT',
-      timeInForce: 'gtc',
-    });
-
-    console.log(new Date(), 'WS API "submitNewOrder()" result: ', res);
-  } catch (e) {
-    console.error(new Date(), 'Exception with WS API "submitNewOrder()": ', e);
-  }
+export interface CreateSubAccountApiKeyRequestV2 {
+  subUid: string;
+  passphrase: string;
+  label?: string;
+  ipList: string[];
+  permType: string;
+  permList: string[];
 }
-
-start().catch((e) => console.error('Exception in example: '.e));
-```
-
-#### ws.sendWSAPIRequest(wsKey, command, category, operation)
-
-This is the "raw" integration within the existing WebSocket client. It uses an automatically persisted & authenticated connection to send events through Bitget's WebSocket API. It automatically tracks and connects outgoing requests with incoming responses, and returns promises that resolve/reject when a matching response is received.
-
-Refer to [V3/ws-api-trade-raw.ts](./V3/ws-api-trade-raw.ts) to see an example.
-
-Note: The WebsocketClient is built around this. For a more user friendly experience, it is recommended to use the WebsocketClient for WS API requests. It uses this method but has the convenience of behaving similar to a REST API (while all communication automatically happens over a persisted WebSocket connection).
-
-## V2
-
-These examples are for Bitget's V2 APIs and WebSockets. They can be found in the examples/V2 folder.
-
-Refer to the V2 API documentation for more information on the V2 APIs:
-https://www.bitget.com/api-doc/common/intro
+⋮----
+export interface ModifySubAccountApiKeyRequestV2 {
+  subUid: string;
+  apiKey: string;
+  label?: string;
+  passphrase: string;
+  ipList?: string[];
+  permType?: string;
+  permList: string[];
+}
+⋮----
+/**
+ *
+ * * Broker | All Sub-accounts Deposit and Withdrawal Records
+ *
+ */
+⋮----
+export interface GetAllSubDepositWithdrawalRequestV2 {
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  idLessThan?: string;
+  type?: 'all' | 'deposit' | 'withdrawal';
+}
+⋮----
+/**
+ *
+ * * Broker | Subaccounts
+ *
+ */
+⋮----
+export interface GetBrokerSubaccountsRequestV2 {
+  startTime?: string;
+  endTime?: string;
+  pageSize?: string;
+  pageNo?: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Commissions
+ *
+ */
+⋮----
+export interface GetBrokerCommissionsRequestV2 {
+  startTime?: string;
+  endTime?: string;
+  pageSize?: string;
+  pageNo?: string;
+  bizType?: 'spot' | 'futures';
+  subBizType?:
+    | 'spot_trade'
+    | 'spot_margin'
+    | 'usdt_futures'
+    | 'usdc_futures'
+    | 'coin_futures';
+}
+⋮----
+/**
+ *
+ * * Broker | Trade Volume
+ *
+ */
+⋮----
+export interface GetBrokerTradeVolumeRequestV2 {
+  startTime?: string;
+  endTime?: string;
+  pageSize?: string;
+  pageNo?: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Total Commission
+ *
+ */
+⋮----
+export interface GetBrokerTotalCommissionRequestV2 {
+  startTime?: string;
+  endTime?: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Order Commission
+ *
+ */
+⋮----
+export interface GetBrokerOrderCommissionRequestV2 {
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  uid?: string;
+  orderId?: string;
+  idLessThan?: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Rebate Info
+ *
+ */
+⋮----
+export interface GetBrokerRebateInfoRequestV2 {
+  uid: string;
+}
 
 ================
 File: src/types/request/v3/account.ts
@@ -9031,225 +7824,2147 @@ export interface SetDepositAccountRequestV3 {
   coin: string;
   accountType: 'funding' | 'unified' | 'otc';
 }
+⋮----
+export interface GetMaxTransferableRequestV3 {
+  coin: string;
+}
+⋮----
+export interface GetOpenInterestLimitRequestV3 {
+  symbol: string;
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+}
+⋮----
+export interface GetTaxRecordsRequestV3 {
+  bizType:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES'
+    | 'OTHER';
+  marginType?: 'isolated' | 'crossed';
+  coin?: string;
+  startTime: string;
+  endTime: string;
+  limit?: string;
+  cursor?: string;
+}
 
 ================
-File: src/types/response/v3/trade.ts
+File: src/types/response/v2/broker.ts
 ================
-export interface BatchModifyOrderResponseV3 {
-  orderId: string;
-  clientOid: string;
+/**
+ *
+ * * Broker | Subaccount
+ *
+ */
+⋮----
+export interface CreateSubaccountResponseV2 {
+  subUid: string;
+  subaccountName: string;
+  status: string;
+  permList: string[];
+  label: string;
+  cTime: string;
 }
 ⋮----
-export interface CancelAllOrdersResponseV3 {
-  list: {
-    orderId: string;
-    clientOid: string;
-    code: string;
-    msg: string;
-  }[];
+export interface BrokerSubaccountV2 {
+  subUid: string;
+  subaccountName: string;
+  status: string;
+  permList: string[];
+  label: string;
+  language: string;
+  cTime: string;
+  uTime: string;
 }
 ⋮----
-export interface CancelBatchOrdersResponseV3 {
-  orderId: string;
-  clientOid: string;
-  code?: string;
-  msg?: string;
+export interface ModifySubaccountResponseV2 {
+  subUid: string;
+  subaccountName: string;
+  status: string;
+  permList: string[];
+  label: string;
+  language: string;
+  cTime: string;
+  uTime: string;
 }
 ⋮----
-export interface CloseAllPositionsResponseV3 {
-  list: {
-    orderId: string;
-    clientOid: string;
-    code: string;
-    msg: string;
-  }[];
+export interface SubaccountEmailV2 {
+  subUid: string;
+  subaccountName: string;
+  subaccountEmail: string;
+  cTime: string;
+  uTime: string;
 }
 ⋮----
-export interface CancelOrderResponseV3 {
-  orderId: string;
-  clientOid: string;
-}
-⋮----
-export interface GetMaxOpenAvailableResponseV3 {
-  available: string;
-  maxOpen: string;
-  buyOpenCost: string;
-  sellOpenCost: string;
-  maxBuyOpen: string;
-  maxSellOpen: string;
-}
-⋮----
-export interface FeeDetailV3 {
-  feeCoin: string;
-  fee: string;
-}
-⋮----
-export interface OrderInfoV3 {
-  orderId: string;
-  clientOid: string;
-  category: string;
-  symbol: string;
-  orderType: string;
-  side: string;
-  price: string;
-  qty: string;
-  amount: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  avgPrice: string;
-  timeInForce: string;
-  orderStatus: string;
-  posSide: string;
-  holdMode: string;
-  reduceOnly: string;
-  feeDetail: FeeDetailV3[];
-  cancelReason: string;
-  execType: string;
-  stpMode?: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-export interface FillV3 {
-  execId: string;
-  orderId: string;
-  category: string;
-  symbol: string;
-  orderType: string;
-  side: string;
-  execPrice: string;
-  execQty: string;
-  execValue: string;
-  tradeScope: string;
-  feeDetail: FeeDetailV3[];
-  execPnl?: string;
-  tradeSide?: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-export interface UnfilledOrderV3 {
-  orderId: string;
-  clientOid: string;
-  category: string;
-  symbol: string;
-  orderType: string;
-  side: string;
-  price: string;
-  qty: string;
-  amount: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  avgPrice: string;
-  timeInForce: string;
-  orderStatus: string;
-  posSide: string;
-  holdMode: string;
-  reduceOnly: string;
-  feeDetail: FeeDetailV3[];
-  stpMode?: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-export interface HistoryOrderV3 {
-  orderId: string;
-  clientOid: string;
-  category: string;
-  symbol: string;
-  orderType: string;
-  side: string;
-  price: string;
-  qty: string;
-  amount: string;
-  cumExecQty: string;
-  cumExecValue: string;
-  avgPrice: string;
-  timeInForce: string;
-  orderStatus: string;
-  posSide: string;
-  holdMode: string;
-  reduceOnly: string;
-  feeDetail: FeeDetailV3[];
-  cancelReason: string;
-  execType: string;
-  stpMode?: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-export interface PositionHistoryV3 {
-  positionId: string;
-  category: string;
-  symbol: string;
-  marginCoin: string;
-  holdMode: string;
-  posSide: string;
-  marginMode: string;
-  openPriceAvg: string;
-  closePriceAvg: string;
-  openTotalPos: string;
-  closeTotalPos: string;
-  cumRealisedPnl: string;
-  netProfit: string;
-  totalFunding: string;
-  openFeeTotal: string;
-  closeFeeTotal: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-export interface CurrentPositionV3 {
-  category: string;
-  symbol: string;
-  marginCoin: string;
-  holdMode: string;
-  posSide: string;
-  marginMode: string;
-  positionBalance: string;
+export interface BrokerSubaccountSpotAssetV2 {
+  coin: string;
   available: string;
   frozen: string;
+  locked: string;
+  uTime: string;
+}
+⋮----
+export interface BrokerSubaccountFutureAssetV2 {
+  marginCoin: string;
+  available: string;
+  frozen: string;
+  locked: string;
+  crossedMaxAvailable: string;
+  isolatedMaxAvailable: string;
+  maxTransferOut: string;
+  accountEquity: string;
+  usdtEquity: string;
+  btcEquity: string;
+  uTime: string;
+}
+⋮----
+export interface CreateSubaccountDepositAddressV2 {
+  subUid: string;
+  coin: string;
+  address: string;
+  chain: string;
+  tag: string;
+  url: string;
+  cTime: string;
+}
+⋮----
+export interface SubaccountDepositV2 {
+  orderId: string;
+  txId: string;
+  coin: string;
+  type: string;
+  dest: string;
+  amount: string;
+  status: string;
+  fromAddress: string;
+  toAddress: string;
+  fee: string;
+  chain: string;
+  confirm: string;
+  tag: string;
+  cTime: string;
+  uTime: string;
+}
+⋮----
+export interface BrokerSubaccountWithdrawalV2 {
+  orderId: string;
+  txId: string;
+  coin: string;
+  type: string;
+  dest: string;
+  amount: string;
+  status: string;
+  fromAddress: string;
+  toAddress: string;
+  fee: string;
+  chain: string;
+  confirm: string;
+  tag: string;
+  userId: string;
+  cTime: string;
+  uTime: string;
+}
+⋮----
+/**
+ *
+ *  Broker | Api Key
+ *
+ */
+⋮----
+export interface CreateSubaccountApiKeyResponseV2 {
+  subUid: string;
+  apiKey: string;
+  secretKey: string;
+  label: string;
+  ipList: string[];
+  permType: string;
+  permList: string[];
+}
+⋮----
+export interface SubaccountApiKeyV2 {
+  subUid: string;
+  label: string;
+  apiKey: string;
+  secretKey: string;
+  permType: string;
+  permList: string[];
+  ipList: string[];
+}
+⋮----
+export interface ModifySubaccountApiKeyResponseV2 {
+  subUid: string;
+  apiKey: string;
+  label: string;
+  ipList: string[];
+  permType: string;
+  permList: string[];
+}
+⋮----
+/**
+ *
+ * * Broker | All Sub-accounts Deposit and Withdrawal Records
+ *
+ */
+⋮----
+export interface AllSubDepositWithdrawalRecordV2 {
+  uid: string;
+  txId: string;
+  type: 'deposit' | 'withdrawal';
+  subType: 'onchain' | 'internal' | 'fast';
+  coin: string;
+  amount: string;
+  status: 'pending' | 'fail' | 'success';
+  ts: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Subaccounts
+ *
+ */
+⋮----
+export interface BrokerSubaccountInfoV2 {
+  uid: string;
+  asset: string;
+  firstTimeDeposit: string;
+  firstTimeTrade: string;
+  registerTime: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Commissions
+ *
+ */
+⋮----
+export interface BrokerCommissionV2 {
+  uid: string;
+  coin: string;
+  symbol: string;
+  dealtAmount: string;
+  totalFee: string;
+  deductedFee: string;
+  paidFee: string;
+  markUpFee: string;
+  totalCommission: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Trade Volume
+ *
+ */
+⋮----
+export interface BrokerTradeVolumeV2 {
+  uid: string;
+  volume: string;
+  spotVolume: string;
+  futureVolume: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Total Commission
+ *
+ */
+⋮----
+export interface BrokerTotalCommissionV2 {
+  date: string;
+  totalTradingVolume: string;
+  totalActiveTraders: string;
+  totalCommission: string;
+  spot: {
+    spotTradingVolume: string;
+    spotTradingFee: string;
+    spotPureTradingFee: string;
+    spotCommission: string;
+  };
+  futures: {
+    futuresTradingVolume: string;
+    futuresTradingFee: string;
+    futuresPureTradingFee: string;
+    futuresCommission: string;
+  };
+}
+⋮----
+/**
+ *
+ * * Broker | Order Commission
+ *
+ */
+⋮----
+export interface BrokerOrderCommissionItemV2 {
+  fillId: string;
+  orderId: string;
+  ts: string;
+  clientOid: string;
+  bizType: 'spot' | 'futures';
+  subBizType:
+    | 'spot_trade'
+    | 'spot_margin'
+    | 'usdt_futures'
+    | 'coin_futures'
+    | 'usdc_futures';
+  symbol: string;
+  volume: string;
+  fee: string;
+  pureFee: string;
+  rebateAmount: string;
+}
+⋮----
+export interface BrokerOrderCommissionV2 {
+  commissionlist: BrokerOrderCommissionItemV2[];
+  endId: string;
+}
+⋮----
+/**
+ *
+ * * Broker | Rebate Info
+ *
+ */
+⋮----
+export interface BrokerRebateInfoV2 {
+  affiliationType: 'affiliate' | 'official';
+  userLevel: string;
+  clientSpotRebateRatio: string;
+  clientFuturesRebateRatio: string;
+}
+
+================
+File: src/types/response/v2/futures.ts
+================
+/**
+ *
+ * * Futures | Market
+ *
+ */
+⋮----
+export interface FuturesVipFeeRateV2 {
+  level: string;
+  dealAmount: string;
+  assetAmount: string;
+  takerFeeRate: string;
+  makerFeeRate: string;
+  btcWithdrawAmount: string;
+  usdtWithdrawAmount: string;
+}
+⋮----
+export interface FuturesHistoryInterestRateV2 {
+  ts: string;
+  annualInterestRate: string;
+  dailyInterestRate: string;
+}
+⋮----
+export interface FuturesInterestExchangeRateV2 {
+  tier: string;
+  minAmount: string;
+  maxAmount: string;
+  exchangeRate: string;
+}
+⋮----
+export interface FuturesDiscountRateV2 {
+  tier: string;
+  minAmount: string;
+  maxAmount: string;
+  discountRate: string;
+}
+⋮----
+export interface FuturesDiscountRatesV2 {
+  coin: string;
+  userLimit: string;
+  totalLimit: string;
+  discountRateList: FuturesDiscountRateV2[];
+}
+⋮----
+export interface FuturesMergeDepthV2 {
+  asks: [number, number][];
+  bids: [number, number][];
+  ts: string;
+  scale: string;
+  precision: string;
+  isMaxPrecision: string;
+}
+⋮----
+export interface FuturesTickerV2 {
+  symbol: string;
+  lastPr: string;
+  askPr: string;
+  bidPr: string;
+  bidSz: string;
+  askSz: string;
+  high24h: string;
+  low24h: string;
+  ts: string;
+  change24h: string;
+  baseVolume: string;
+  quoteVolume: string;
+  usdtVolume: string;
+  openUtc: string;
+  changeUtc24h: string;
+  indexPrice: string;
+  fundingRate: string;
+  holdingAmount: string;
+  deliveryStartTime: string;
+  deliveryTime: string;
+  deliveryStatus: string;
+  open24h: string;
+  markPrice: string;
+}
+⋮----
+export interface FuturesFillV2 {
+  tradeId: string;
+  price: string;
+  size: string;
+  side: string;
+  ts: string;
+  symbol: string;
+}
+⋮----
+export type FuturesCandlestickV2 = [
+  string, // timestamp
+  string, // open
+  string, // high
+  string, // low
+  string, // close
+  string, // baseVolume
+  string, // usdtVolume
+  string, // quoteVolume
+];
+⋮----
+string, // timestamp
+string, // open
+string, // high
+string, // low
+string, // close
+string, // baseVolume
+string, // usdtVolume
+string, // quoteVolume
+⋮----
+export interface FuturesOpenInterestV2 {
+  symbol: string;
+  size: string;
+}
+⋮----
+export interface FuturesFundingTimeV2 {
+  symbol: string;
+  nextFundingTime: string;
+  ratePeriod: string;
+}
+⋮----
+export interface FuturesSymbolPriceV2 {
+  symbol: string;
+  price: string;
+  indexPrice: string;
+  markPrice: string;
+  ts: string;
+}
+⋮----
+export interface FuturesHistoricalFundingRateV2 {
+  symbol: string;
+  fundingRate: string;
+  fundingTime: string;
+}
+⋮----
+export interface FuturesContractConfigV2 {
+  symbol: string;
+  baseCoin: string;
+  quoteCoin: string;
+  buyLimitPriceRatio: string;
+  sellLimitPriceRatio: string;
+  feeRateUpRatio: string;
+  makerFeeRate: string;
+  takerFeeRate: string;
+  openCostUpRatio: string;
+  supportMarginCoins: string[];
+  minTradeNum: string;
+  priceEndStep: string;
+  volumePlace: string;
+  pricePlace: string;
+  sizeMultiplier: string;
+  symbolType: string;
+  minTradeUSDT: string;
+  maxSymbolOrderNum: string;
+  maxProductOrderNum: string;
+  maxPositionNum: string;
+  symbolStatus: string;
+  offTime: string;
+  limitOpenTime: string;
+  deliveryTime: string;
+  deliveryStartTime: string;
+  launchTime: string;
+  fundInterval: string;
+  minLever: string;
+  maxLever: string;
+  posLimit: string;
+  maintainTime: string;
+  isRwa: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account
+ *
+ */
+⋮----
+export interface FuturesAccountV2 {
+  marginCoin: string;
+  locked: string;
+  available: string;
+  crossedMaxAvailable: string;
+  isolatedMaxAvailable: string;
+  maxTransferOut: string;
+  accountEquity: string;
+  usdtEquity: string;
+  btcEquity: string;
+  crossedRiskRate: string;
+  crossedMarginLeverage: string;
+  isolatedLongLever: string;
+  isolatedShortLever: string;
+  marginMode: string;
+  posMode: string;
+  unrealizedPL: string;
+  coupon: string;
+  crossedUnrealizedPL: string;
+  isolatedUnrealizedPL: string;
+  assetMode: string;
+}
+⋮----
+export interface FuturesAccountsV2 {
+  marginCoin: string;
+  locked: string;
+  available: string;
+  crossedMaxAvailable: string;
+  isolatedMaxAvailable: string;
+  maxTransferOut: string;
+  accountEquity: string;
+  usdtEquity: string;
+  btcEquity: string;
+  crossedRiskRate: string;
+  unrealizedPL: string;
+  coupon: string;
+  unionTotalMagin: string;
+  unionAvailable: string;
+  unionMm: string;
+  assetList: {
+    coin: string;
+    balance: string;
+  }[];
+  isolatedMargin: string;
+  crossedMargin: string;
+  crossedUnrealizedPL: string;
+  isolatedUnrealizedPL: string;
+  assetMode: string;
+}
+⋮----
+export interface FuturesSubAccountAssetV2 {
+  marginCoin: string;
+  locked: string;
+  available: string;
+  crossedMaxAvailable: string;
+  isolatedMaxAvailable: string;
+  maxTransferOut: string;
+  accountEquity: string;
+  usdtEquity: string;
+  btcEquity: string;
+  unrealizedPL: string;
+  coupon: string;
+}
+⋮----
+export interface FuturesInterestV2 {
+  coin: string;
+  liability: string;
+  interestFreeLimit: string;
+  interestLimit: string;
+  hourInterestRate: string;
+  interest: string;
+  cTime: string;
+}
+export interface FuturesInterestHistoryV2 {
+  nextSettleTime: string;
+  borrowAmount: string;
+  borrowLimit: string;
+  interestList: FuturesInterestV2[];
+  endId: string;
+}
+⋮----
+export interface SetLeverageResponseV2 {
+  symbol: string;
+  marginCoin: string;
+  longLeverage: string;
+  shortLeverage: string;
+  crossMarginLeverage: string;
+  marginMode: string;
+}
+⋮----
+export interface SetMarginModeResponseV2 {
+  symbol: string;
+  marginCoin: string;
+  longLeverage: string;
+  shortLeverage: string;
+  marginMode: string;
+}
+⋮----
+export interface FuturesAccountBillV2 {
+  billId: string;
+  symbol: string;
+  amount: string;
+  fee: string;
+  feeByCoupon: string;
+  businessType: string;
+  coin: string;
+  balance: string;
+  cTime: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Position
+ *
+ */
+⋮----
+export interface FuturesPositionTierV2 {
+  symbol: string;
+  level: string;
+  startUnit: string;
+  endUnit: string;
+  leverage: string;
+  keepMarginRate: string;
+}
+⋮----
+export interface FuturesPositionV2 {
+  marginCoin: string;
+  symbol: string;
+  holdSide: string;
+  openDelegateSize: string;
+  marginSize: string;
+  available: string;
+  locked: string;
   total: string;
   leverage: string;
-  curRealisedPnl: string;
-  avgPrice: string;
-  positionStatus: string;
-  unrealisedPnl: string;
+  achievedProfits: string;
+  openPriceAvg: string;
+  marginMode: string;
+  posMode: string;
+  unrealizedPL: string;
   liquidationPrice: string;
-  mmr: string;
-  profitRate: string;
+  keepMarginRate: string;
   markPrice: string;
   breakEvenPrice: string;
+  totalFee: string;
+  deductedFee: string;
+  marginRatio: string;
+  assetMode: string;
+  uTime: string;
+  autoMargin: string;
+  cTime: string;
+}
+⋮----
+export interface FuturesHistoryPositionV2 {
+  positionId: string;
+  marginCoin: string;
+  symbol: string;
+  holdSide: string;
+  openAvgPrice: string;
+  closeAvgPrice: string;
+  marginMode: string;
+  openTotalPos: string;
+  closeTotalPos: string;
+  pnl: string;
+  netProfit: string;
   totalFunding: string;
-  openFeeTotal: string;
-  closeFeeTotal: string;
+  openFee: string;
+  closeFee: string;
+  cTime: string;
+  uTime: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Trade
+ *
+ */
+⋮----
+export interface FuturesBatchOrderResponseV2 {
+  successList: {
+    orderId: string;
+    clientOid: string;
+  }[];
+  failureList: {
+    orderId: string;
+    clientOid: string;
+    errorMsg: string;
+    errorCode: string;
+  }[];
+}
+⋮----
+export interface FuturesClosePositionResponseV2 {
+  successList: {
+    orderId: string;
+    clientOid: string;
+    symbol: string;
+  }[];
+  failureList: {
+    orderId: string;
+    clientOid: string;
+    symbol: string;
+    errorMsg: string;
+    errorCode: string;
+  }[];
+}
+⋮----
+export interface FuturesOrderDetailV2 {
+  symbol: string;
+  size: string;
+  orderId: string;
+  clientOid: string;
+  baseVolume: string;
+  priceAvg: string;
+  fee: string;
+  price: string;
+  state: string;
+  side: string;
+  force: string;
+  totalProfits: string;
+  posSide: string;
+  marginCoin: string;
+  presetStopSurplusPrice: string;
+  presetStopLossPrice: string;
+  quoteVolume: string;
+  orderType: string;
+  leverage: string;
+  marginMode: string;
+  reduceOnly: string;
+  enterPointSource: string;
+  tradeSide: string;
+  posMode: string;
+  orderSource: string;
+  cancelReason: string;
+  cTime: string;
+  uTime: string;
+}
+⋮----
+export interface FuturesOrderFillV2 {
+  tradeId: string;
+  symbol: string;
+  orderId: string;
+  price: string;
+  baseVolume: string;
+  feeDetail: {
+    deduction: string;
+    feeCoin: string;
+    totalDeductionFee: string;
+    totalFee: string;
+  }[];
+  side: string;
+  quoteVolume: string;
+  profit: string;
+  enterPointSource: string;
+  tradeSide: string;
+  posMode: string;
+  tradeScope: string;
+  cTime: string;
+}
+⋮----
+export interface FuturesOpenOrderV2 {
+  symbol: string;
+  size: string;
+  orderId: string;
+  clientOid: string;
+  baseVolume: string;
+  fee: string;
+  price: string;
+  priceAvg: string;
+  status: string;
+  side: string;
+  force: string;
+  totalProfits: string;
+  posSide: string;
+  marginCoin: string;
+  quoteVolume: string;
+  leverage: string;
+  marginMode: string;
+  enterPointSource: string;
+  tradeSide: string;
+  posMode: string;
+  orderType: string;
+  orderSource: string;
+  cTime: string;
+  uTime: string;
+  presetStopSurplusPrice: string;
+  presetStopSurplusType: string;
+  presetStopSurplusExecutePrice: string;
+  presetStopLossPrice: string;
+  presetStopLossType: string;
+  presetStopLossExecutePrice: string;
+}
+⋮----
+export interface FuturesHistoryOrderV2 {
+  symbol: string;
+  size: string;
+  orderId: string;
+  clientOid: string;
+  baseVolume: string;
+  fee: string;
+  price: string;
+  priceAvg: string;
+  status: string;
+  side: string;
+  force: string;
+  totalProfits: string;
+  posSide: string;
+  marginCoin: string;
+  quoteVolume: string;
+  leverage: string;
+  marginMode: string;
+  enterPointSource: string;
+  tradeSide: string;
+  posMode: string;
+  orderType: string;
+  orderSource: string;
+  cTime: string;
+  uTime: string;
+  presetStopSurplusPrice: string;
+  presetStopLossPrice: string;
+  liqPrice: string;
+}
+⋮----
+export interface FuturesCancelAllOrdersV2 {
+  successList: {
+    orderId: string;
+    clientOid: string;
+  }[];
+  failureList: {
+    orderId: string;
+    clientOid: string;
+    errorMsg: string;
+    errorCode: string;
+  }[];
+}
+⋮----
+/**
+ *
+ * * Futures | Trigger Orders
+ *
+ */
+⋮----
+export interface FuturesTriggerSubOrderV2 {
+  orderId: string;
+  price: string;
+  type: string;
+  status: string;
+}
+⋮----
+export interface FuturesPendingPlanOrderV2 {
+  planType: string;
+  symbol: string;
+  size: string;
+  orderId: string;
+  clientOid: string;
+  price: string;
+  executePrice: string;
+  callbackRatio: string;
+  triggerPrice: string;
+  triggerType: string;
+  planStatus: string;
+  side: string;
+  posSide: string;
+  marginCoin: string;
+  marginMode: string;
+  enterPointSource: string;
+  tradeSide: string;
+  posMode: string;
+  orderType: string;
+  orderSource: string;
+  cTime: string;
+  uTime: string;
+  stopSurplusExecutePrice: string;
+  stopSurplusTriggerPrice: string;
+  stopSurplusTriggerType: string;
+  stopLossExecutePrice: string;
+  stopLossTriggerPrice: string;
+  stopLossTriggerType: string;
+}
+⋮----
+export interface FuturesCancelPlanOrderV2 {
+  successList: {
+    orderId: string;
+    clientOid: string;
+  }[];
+  failureList: {
+    orderId: string;
+    clientOid: string;
+    errorMsg: string;
+  }[];
+}
+⋮----
+export interface FuturesHistoryPlanOrderV2 {
+  planType: string;
+  symbol: string;
+  size: string;
+  orderId: string;
+  executeOrderId: string;
+  clientOid: string;
+  planStatus: string;
+  price: string;
+  executePrice: string;
+  priceAvg: string;
+  baseVolume: string;
+  callbackRatio: string;
+  triggerPrice: string;
+  triggerType: string;
+  side: string;
+  posSide: string;
+  marginCoin: string;
+  marginMode: string;
+  enterPointSource: string;
+  tradeSide: string;
+  posMode: string;
+  orderType: string;
+  cTime: string;
+  uTime: string;
+  stopSurplusExecutePrice: string;
+  stopSurplusTriggerPrice: string;
+  stopSurplusTriggerType: string;
+  stopLossExecutePrice: string;
+  stopLossTriggerPrice: string;
+  stopLossTriggerType: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Union Margin
+ *
+ */
+⋮----
+export interface UnionTransferLimitsV2 {
+  coin: string;
+  maxTransferIn: string;
+}
+⋮----
+export interface UnionConfigV2 {
+  imr: string;
+  mmr: string;
+  individualLimit: string;
+  individualLimitRatio: string;
+}
+⋮----
+export interface UnionSwitchUsdtV2 {
+  usdtAmount: string;
+}
+⋮----
+export interface UnionConvertV2 {
+  usdtAmount: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account | Max Openable Quantity
+ *
+ */
+⋮----
+export interface FuturesMaxOpenV2 {
+  maxOpen: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account | Liquidation Price
+ *
+ */
+⋮----
+export interface FuturesLiquidationPriceV2 {
+  liqPrice: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account | Isolated Symbols
+ *
+ */
+⋮----
+export interface FuturesIsolatedSymbolV2 {
+  symbol: string;
+  marginMode: 'isolated';
+}
+
+================
+File: src/types/websockets/ws-api-request.ts
+================
+export interface WSAPIPlaceOrderRequestV3 {
+  symbol: string;
+  orderType: 'limit' | 'market';
+  qty: string;
+  price?: string;
+  side: 'buy' | 'sell';
+  posSide?: 'long' | 'short';
+  timeInForce?: 'gtc' | 'ioc' | 'fok' | 'post_only';
+  reduceOnly?: 'YES' | 'NO'; // Note: reduceOnly is not supported for batch place WS API. Might be supported starting late Q4 2025, but not supported yet.
+  clientOid?: string;
+  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
+  tpTriggerBy?: 'market' | 'mark';
+  slTriggerBy?: 'market' | 'mark';
+  takeProfit?: string;
+  stopLoss?: string;
+  tpOrderType?: 'limit' | 'market';
+  slOrderType?: 'limit' | 'market';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+}
+⋮----
+reduceOnly?: 'YES' | 'NO'; // Note: reduceOnly is not supported for batch place WS API. Might be supported starting late Q4 2025, but not supported yet.
+
+================
+File: .gitignore
+================
+!.gitkeep
+.DS_STORE
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+pids
+*.pid
+*.seed
+*.pid.lock
+node_modules/
+.npm
+.eslintcache
+.node_repl_history
+*.tgz
+.yarn-integrity
+.env
+.env.test
+.cache
+lib
+bundleReport.html
+.history/
+tiagoSpot.ts
+restClientRegex.ts
+localtest.sh
+privaterepotracker
+testfile.ts
+dist
+repomix.sh
+coverage
+
+================
+File: examples/README.md
+================
+# Examples
+
+These samples can be executed using `ts-node`:
+
+```
+ts-node ./examples/rest-spot-public.ts
+```
+
+Samples that require authentication can be edited directly but also support environmental variables. E.g. on mac/unix:
+
+```
+API_KEY_COM='yourkeyhere' API_SECRET_COM='yoursecrethere' API_PASS_COM='yourapipasshere' ts-node examples/rest-trade-futures.ts
+```
+
+They can also be converted to JavaScript by changing the imports to require & removing any type annotations.
+
+## V3 / Unified Trading Account (UTA)
+
+These newer examples are for Bitget's V3 APIs and WebSockets. They can be found in the examples/V3 folder.
+
+Refer to the V3 / UTA API documentation for more information on the V3 APIs:
+https://www.bitget.com/api-doc/uta/intro
+
+These APIs require your account to be upgraded to the Unified Trading Account, if you plan on using the account-level REST APIs and WebSockets. Once upgraded, the V2 APIs are no longer available to you, unless you revert back to Classic Account mode.
+
+### WebSocket API (WS API)
+
+The V3/UTA API introduces order placement via a persisted WebSocket connection. This Bitget Node.js, JavaScript & TypeScript SDK supports Bitget's full V3 API offering, including the WebSocket API.
+
+There are two approaches to placing orders via the Bitget WebSocket APIs
+
+#### WebsocketAPIClient (recommended)
+
+This integration looks & feels like a REST API client, but uses WebSockets, via the WebsocketClient's sendWSAPIRequest method. It returns promises and has end to end types.
+
+This is the recommended approach to easily start sending orders via an automatically persisted WebSocket connection. A simple example is below, but for a more thorough example, check the example here: [./V3/ws-api-client-trade.ts](./V3/ws-api-client-trade.ts)
+
+```typescript
+import { WebsocketAPIClient } from 'bitget-api';
+// or if you prefer require:
+// const { WebsocketAPIClient } = require("bitget-api");
+
+// Make an instance of the WS API Client class with your API keys
+const wsClient = new WebsocketAPIClient({
+  apiKey: API_KEY,
+  apiSecret: API_SECRET,
+  apiPass: API_PASS,
+
+  // Whether to use the demo trading wss connection
+  // demoTrading: true,
+});
+
+async function start() {
+  // Start using it like a REST API. All actions are sent via a persisted WebSocket connection.
+
+  /**
+   * Place Order
+   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel#request-parameters
+   */
+  try {
+    const res = await wsClient.submitNewOrder('spot', {
+      orderType: 'limit',
+      price: '100',
+      qty: '0.1',
+      side: 'buy',
+      symbol: 'BTCUSDT',
+      timeInForce: 'gtc',
+    });
+
+    console.log(new Date(), 'WS API "submitNewOrder()" result: ', res);
+  } catch (e) {
+    console.error(new Date(), 'Exception with WS API "submitNewOrder()": ', e);
+  }
+}
+
+start().catch((e) => console.error('Exception in example: '.e));
+```
+
+#### ws.sendWSAPIRequest(wsKey, command, category, operation)
+
+This is the "raw" integration within the existing WebSocket client. It uses an automatically persisted & authenticated connection to send events through Bitget's WebSocket API. It automatically tracks and connects outgoing requests with incoming responses, and returns promises that resolve/reject when a matching response is received.
+
+Refer to [V3/ws-api-trade-raw.ts](./V3/ws-api-trade-raw.ts) to see an example.
+
+Note: The WebsocketClient is built around this. For a more user friendly experience, it is recommended to use the WebsocketClient for WS API requests. It uses this method but has the convenience of behaving similar to a REST API (while all communication automatically happens over a persisted WebSocket connection).
+
+## V2
+
+These examples are for Bitget's V2 APIs and WebSockets. They can be found in the examples/V2 folder.
+
+Refer to the V2 API documentation for more information on the V2 APIs:
+https://www.bitget.com/api-doc/common/intro
+
+================
+File: src/types/request/v2/futures.ts
+================
+import { FuturesPlanTypeV2, FuturesProductTypeV2 } from '../shared.js';
+import { FuturesKlineInterval } from '../v1/futuresV1.js';
+⋮----
+export type FuturesKlineTypeV2 = 'MARKET' | 'MARK' | 'INDEX';
+⋮----
+export interface FuturesAccountBillRequestV2 {
+  productType: FuturesProductTypeV2;
+  symbol?: string;
+  coin?: string;
+  businessType?: string;
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Market
+ *
+ */
+⋮----
+export interface FuturesMergeDepthRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  precision?: 'scale0' | 'scale1' | 'scale2' | 'scale3';
+  limit?: '1' | '5' | '15' | '50' | 'max';
+}
+⋮----
+export interface FuturesRecentTradesRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  limit?: string;
+}
+⋮----
+export interface FuturesHistoricTradesRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  limit?: string;
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+}
+⋮----
+export interface FuturesCandlesRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  granularity: FuturesKlineInterval;
+  startTime?: string;
+  endTime?: string;
+  kLineType?: FuturesKlineTypeV2;
+  limit?: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account
+ *
+ */
+⋮----
+export interface FuturesSingleAccountRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+}
+⋮----
+export interface FuturesInterestHistoryRequestV2 {
+  productType: 'USDT-FUTURES' | 'SUSDT-FUTURES';
+  coin?: string;
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+export interface FuturesOpenCountRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  openAmount: string;
+  openPrice: string;
+  leverage?: string;
+}
+⋮----
+export interface FuturesSetAutoMarginRequestV2 {
+  symbol: string;
+  autoMargin: 'on' | 'off';
+  marginCoin: string;
+  amount: string;
+  holdSide?: 'long' | 'short';
+}
+⋮----
+export interface FuturesSetLeverageRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  leverage: string;
+  holdSide?: 'long' | 'short';
+}
+⋮----
+export interface FuturesSetPositionMarginRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  holdSide: 'long' | 'short';
+  amount: string;
+}
+⋮----
+export interface FuturesSetMarginModeRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  marginMode: 'isolated' | 'crossed';
+}
+⋮----
+/**
+ *
+ * * Futures | Position
+ *
+ */
+⋮----
+export interface FuturesHistoricalPositionsRequestV2 {
+  symbol?: string;
+  productType?: FuturesProductTypeV2;
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Trade
+ *
+ */
+⋮----
+export interface FuturesPlaceOrderRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginMode: 'isolated' | 'crossed';
+  marginCoin: string;
+  size: string;
+  price?: string;
+  side: 'buy' | 'sell';
+  tradeSide?: 'open' | 'close';
+  orderType: 'limit' | 'market';
+  force?: 'ioc' | 'fok' | 'gtc' | 'post_only';
+  clientOid?: string;
+  reduceOnly?: 'YES' | 'NO';
+  presetStopSurplusPrice?: string;
+  presetStopLossPrice?: string;
+  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
+}
+⋮----
+export interface FuturesReversalOrderRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  size: string;
+  side?: 'buy' | 'sell';
+  tradeSide?: 'open' | 'close';
+  clientOid?: string;
+}
+⋮----
+interface FuturesBatchOrderItem {
+  size: string;
+  price?: string;
+  side: 'buy' | 'sell';
+  tradeSide?: 'open' | 'close';
+  orderType: 'limit' | 'market';
+  force?: 'ioc' | 'fok' | 'gtc' | 'post_only';
+  clientOid?: string;
+  reduceOnly?: 'YES' | 'NO';
+  presetStopSurplusPrice?: string;
+  presetStopLossPrice?: string;
+  stpMode?: 'none' | 'cancel_taker' | 'cancel_maker' | 'cancel_both';
+}
+⋮----
+export interface FuturesBatchOrderRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  marginMode: 'isolated' | 'crossed';
+  orderList: FuturesBatchOrderItem[];
+}
+⋮----
+export interface FuturesModifyOrderRequestV2 {
+  orderId?: string;
+  clientOid?: string;
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  newClientOid: string;
+  newSize?: string;
+  newPrice?: string;
+  newPresetStopSurplusPrice?: string;
+  newPresetStopLossPrice?: string;
+}
+⋮----
+export interface FuturesCancelOrderRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin?: string;
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+interface FuturesBatchCancelOrderItem {
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+export interface FuturesBatchCancelOrderRequestV2 {
+  orderIdList?: FuturesBatchCancelOrderItem[];
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  marginCoin?: string;
+}
+⋮----
+export interface FuturesFlashClosePositionsRequestV2 {
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  holdSide?: 'long' | 'short';
+}
+⋮----
+export interface FuturesGetOrderRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+export interface FuturesGetOrderFillsRequestV2 {
+  orderId?: string;
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+export interface FuturesGetHistoricalFillsRequestV2 {
+  orderId?: string;
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  startTime?: string;
+  endTime?: string;
+  idLessThan?: string;
+  limit?: string;
+}
+⋮----
+export interface FuturesGetOpenOrdersRequestV2 {
+  orderId?: string;
+  clientOid?: string;
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  status?: 'live' | 'partially_filled';
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+export type FuturesOrderSourceV2 =
+  | 'normal'
+  | 'market'
+  | 'profit_market'
+  | 'loss_market'
+  | 'Trader_delegate'
+  | 'trader_profit'
+  | 'trader_loss'
+  | 'reverse'
+  | 'trader_reverse'
+  | 'profit_limit'
+  | 'loss_limit'
+  | 'liquidation'
+  | 'delivery_close_long'
+  | 'delivery_close_short'
+  | 'pos_profit_limit'
+  | 'pos_profit_market'
+  | 'pos_loss_limit'
+  | 'pos_loss_market';
+⋮----
+export interface FuturesGetHistoryOrdersRequestV2 {
+  orderId?: string;
+  clientOid?: string;
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  idLessThan?: string;
+  orderSource?: FuturesOrderSourceV2;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+export interface FuturesCancelAllOrdersRequestV2 {
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  marginCoin?: string;
+  requestTime?: string;
+  receiveWindow?: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Trigger Orders
+ *
+ */
+⋮----
+export type FuturesTriggerTypeV2 = 'fill_price' | 'mark_price';
+⋮----
+export type FuturesStpModeV2 =
+  | 'none'
+  | 'cancel_taker'
+  | 'cancel_maker'
+  | 'cancel_both';
+⋮----
+export interface FuturesTPSLOrderRequestV2 {
+  marginCoin: string;
+  productType: FuturesProductTypeV2;
+  symbol: string;
+  planType: FuturesPlanTypeV2;
+  triggerPrice: string;
+  triggerType?: FuturesTriggerTypeV2;
+  executePrice?: string;
+  holdSide: 'long' | 'short' | 'buy' | 'sell';
+  size: string;
+  rangeRate?: string;
+  clientOid?: string;
+  stpMode?: FuturesStpModeV2;
+}
+⋮----
+export type FuturesTriggerPriceTypeV2 =
+  | 'fill_price'
+  | 'mark_price'
+  | 'index_price';
+⋮----
+export interface FuturesPlanOrderRequestV2 {
+  planType: 'normal_plan' | 'track_plan';
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginMode: 'isolated' | 'crossed';
+  marginCoin: string;
+  size: string;
+  price?: string;
+  callbackRatio?: string;
+  triggerPrice: string;
+  triggerType: 'mark_price' | 'fill_price';
+  side: 'buy' | 'sell';
+  tradeSide?: 'open' | 'close';
+  orderType: 'limit' | 'market';
+  clientOid?: string;
+  reduceOnly?: 'YES' | 'NO';
+  stopSurplusTriggerPrice?: string;
+  stopSurplusExecutePrice?: string;
+  stopSurplusTriggerType?: FuturesTriggerPriceTypeV2;
+  stopLossTriggerPrice?: string;
+  stopLossExecutePrice?: string;
+  stopLossTriggerType?: FuturesTriggerPriceTypeV2;
+  stpMode?: FuturesStpModeV2;
+}
+⋮----
+export interface FuturesModifyTPSLOrderRequestV2 {
+  orderId?: string;
+  clientOid?: string;
+  marginCoin: string;
+  productType: FuturesProductTypeV2;
+  symbol: string;
+  triggerPrice: string;
+  triggerType?: 'fill_price' | 'mark_price';
+  executePrice?: string;
+  size: string;
+  rangeRate?: string;
+}
+⋮----
+export interface FuturesModifyPlanOrderRequestV2 {
+  planType: 'normal_plan' | 'track_plan';
+  orderId?: string;
+  clientOid?: string;
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  newSize?: string;
+  newPrice?: string;
+  newCallbackRatio?: string;
+  newTriggerPrice?: string;
+  newTriggerType?: 'fill_price' | 'mark_price';
+  newStopSurplusTriggerPrice?: string;
+  newStopSurplusExecutePrice?: string;
+  newStopSurplusTriggerType?: FuturesTriggerPriceTypeV2;
+  newStopLossTriggerPrice?: string;
+  newStopLossExecutePrice?: string;
+  newStopLossTriggerType?: FuturesTriggerPriceTypeV2;
+}
+⋮----
+export interface FuturesGetPlanOrdersRequestV2 {
+  orderId?: string;
+  clientOid?: string;
+  symbol?: string;
+  planType: 'normal_plan' | 'track_plan' | 'profit_loss';
+  productType: FuturesProductTypeV2;
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+interface FuturesCancelPlanOrderItemV2 {
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+export type FuturesPlanOrderTypeV2 =
+  | 'normal_plan'
+  | 'profit_plan'
+  | 'loss_plan'
+  | 'pos_profit'
+  | 'pos_loss'
+  | 'moving_plan';
+⋮----
+export interface FuturesCancelPlanOrderRequestV2 {
+  orderIdList?: FuturesCancelPlanOrderItemV2[];
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  marginCoin?: string;
+  planType?: FuturesPlanOrderTypeV2;
+}
+⋮----
+export type FuturesPlanStatusV2 = 'executed' | 'fail_trigger' | 'cancelled';
+⋮----
+export interface FuturesGetHistoryPlanOrdersRequestV2 {
+  orderId?: string;
+  clientOid?: string;
+  planType: 'normal_plan' | 'track_plan' | 'profit_loss';
+  planStatus?: FuturesPlanStatusV2;
+  symbol?: string;
+  productType: FuturesProductTypeV2;
+  idLessThan?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Union Margin
+ *
+ */
+⋮----
+export interface GetUnionTransferLimitsRequestV2 {
+  coin: string;
+}
+⋮----
+export interface UnionConvertRequestV2 {
+  coin: string;
+  amount: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account | Max Openable Quantity
+ *
+ */
+⋮----
+export interface FuturesMaxOpenRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  posSide: 'long' | 'short';
+  orderType: 'limit' | 'market';
+  openPrice?: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account | Liquidation Price
+ *
+ */
+⋮----
+export interface FuturesLiquidationPriceRequestV2 {
+  symbol: string;
+  productType: FuturesProductTypeV2;
+  marginCoin: string;
+  posSide: 'long' | 'short';
+  orderType: 'limit' | 'market';
+  openAmount: string;
+  openPrice?: string;
+}
+⋮----
+/**
+ *
+ * * Futures | Account | Isolated Symbols
+ *
+ */
+⋮----
+export interface FuturesIsolatedSymbolsRequestV2 {
+  productType: FuturesProductTypeV2;
+}
+
+================
+File: src/types/response/v3/account.ts
+================
+// Account Management Response Types
+export interface AccountSymbolConfigV3 {
+  category: string;
+  symbol: string;
+  marginMode: string;
+  leverage: string;
+}
+⋮----
+export interface AccountCoinConfigV3 {
+  coin: string;
+  leverage: string;
+}
+⋮----
+export interface AccountSettingsV3 {
+  assetMode: string;
+  holdMode: string;
+  symbolConfigList: AccountSymbolConfigV3[];
+  coinConfigList: AccountCoinConfigV3[];
+}
+⋮----
+export interface AccountAssetV3 {
+  coin: string;
+  equity: string;
+  usdValue: string;
+  balance: string;
+  available: string;
+  debt: string;
+  locked: string;
+}
+⋮----
+export interface AccountAssetsV3 {
+  accountEquity: string;
+  usdtEquity: string;
+  btcEquity: string;
+  unrealisedPnl: string;
+  usdtUnrealisedPnl: string;
+  btcUnrealizedPnl: string;
+  effEquity: string;
+  mmr: string;
+  imr: string;
+  mgnRatio: string;
+  positionMgnRatio: string;
+  assets: AccountAssetV3[];
+}
+⋮----
+export interface ConvertRecordV3 {
+  fromCoin: string;
+  fromCoinSize: string;
+  toCoin: string;
+  toCoinSize: string;
+  price: string;
+  ts: string;
+}
+⋮----
+export interface FinancialRecordV3 {
+  category: string;
+  id: string;
+  symbol: string;
+  coin: string;
+  type: string;
+  amount: string;
+  fee: string;
+  balance: string;
+  ts: string;
+}
+⋮----
+export interface PaymentCoinV3 {
+  coin: string;
+  size: string;
+  amount: string;
+}
+⋮----
+export interface RepayableCoinV3 {
+  coin: string;
+  size: string;
+  amount: string;
+}
+⋮----
+export interface RepayResponseV3 {
+  result: string;
+  repayAmount: string;
+}
+⋮----
+// Sub-account Management Response Types
+⋮----
+export interface CreateSubAccountApiKeyResponseV3 {
+  note: string;
+  apiKey: string;
+  secret: string;
+  type: string;
+  permissions: string[];
+  ips: string[];
+}
+export interface SubAccountApiKeyV3 {
+  apiKey: string;
+  note: string;
+  type: string;
+  permissions: string[];
+  ips: string[];
+  ts?: string;
+}
+⋮----
+export interface UpdateSubAccountApiKeyResponseV3 {
+  note: string;
+  apiKey: string;
+  type: string;
+  permissions: string[];
+  ips: string[];
+}
+⋮----
+export interface CreateSubAccountResponseV3 {
+  username: string;
+  subUid: string;
+  status: string;
+  note: string;
   createdTime: string;
   updatedTime: string;
 }
 ⋮----
-export interface ModifyOrderResponseV3 {
+export interface SubAccountV3 {
+  subUid: string;
+  username: string;
+  status: string;
+  accountMode: string;
+  type: string;
+  note: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+// Transfer Response Types
+⋮----
+export interface TransferResponseV3 {
+  transferId: string;
+}
+⋮----
+export interface SubTransferRecordV3 {
+  transferId: string;
+  oldTransferId?: string;
+  fromType: string;
+  toType: string;
+  amount: string;
+  coin: string;
+  fromUserId: string;
+  toUserId: string;
+  status: string;
+  clientOid: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+export interface SubUnifiedAssetV3 {
+  coin: string;
+  equity: string;
+  usdValue: string;
+  balance: string;
+  available: string;
+  debt: string;
+  locked: string;
+}
+⋮----
+export interface SubUnifiedAssetV3 {
+  subUid: string;
+  cursor: string;
+  assets: SubUnifiedAssetV3[];
+}
+⋮----
+export interface GetFeeRateResponseV3 {
+  makerFeeRate: string;
+  takerFeeRate: string;
+}
+⋮----
+export interface FundingAssetV3 {
+  coin: string;
+  available: string;
+  frozen: string;
+  balance: string;
+}
+⋮----
+// Deposit Response Types
+⋮----
+export interface DepositAddressV3 {
+  address: string;
+  chain: string;
+  coin: string;
+  tag: string;
+  url: string;
+}
+⋮----
+export interface DepositRecordV3 {
+  orderId: string;
+  recordId: string;
+  coin: string;
+  type: 'deposit';
+  dest: 'on_chain' | 'internal_transfer';
+  size: string;
+  status: 'pending' | 'success' | 'fail';
+  fromAddress: string;
+  toAddress: string;
+  chain: string;
+  createdTime: string;
+  updatedTime: string;
+}
+⋮----
+// Withdraw Response Types
+⋮----
+export interface WithdrawResponseV3 {
   orderId: string;
   clientOid: string;
 }
 ⋮----
-export interface PlaceBatchOrdersResponseV3 {
+export interface WithdrawRecordV3 {
   orderId: string;
   clientOid: string;
-  code?: string;
-  msg?: string;
+  recordId: string;
+  coin: string;
+  type: 'withdraw';
+  dest: 'on_chain' | 'internal_transfer';
+  size: string;
+  status: 'pending' | 'success' | 'fail';
+  fromAddress: string;
+  toAddress: string;
+  chain: string;
+  fee: string;
+  confirm: string;
+  tag: string;
+  createdTime: string;
+  updatedTime: string;
 }
 ⋮----
-export interface PlaceOrderResponseV3 {
-  orderId: string;
-  clientOid: string;
+export interface MaxTransferableV3 {
+  coin: string;
+  maxTransfer: string;
+  borrowMaxTransfer: string;
 }
 ⋮----
-export interface PositionAdlRankV3 {
+export interface OpenInterestLimitV3 {
   symbol: string;
-  marginCoin: string;
-  adlRank: string;
-  holdSide: 'long' | 'short';
+  singleUserLimit: string;
+  masterSubLimit: string;
+  marketMakerLimit: string;
 }
+⋮----
+export interface TaxRecordV3 {
+  id: string;
+  coin: string;
+  type: string;
+  amount: string;
+  fee: string;
+  balance: string;
+  ts: string;
+}
+
+================
+File: src/websocket-client-legacy-v1.ts
+================
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
+import { EventEmitter } from 'events';
+import WebSocket from 'isomorphic-ws';
+⋮----
+import {
+  BitgetInstType,
+  WebsocketClientOptions,
+  WSClientConfigurableOptions,
+  WsKey,
+  WsTopic,
+  WsTopicSubscribeEventArgs,
+} from './types/websockets/ws-general.js';
+import { DefaultLogger } from './util/logger.js';
+import { isWsPong } from './util/requestUtils.js';
+import { signMessage } from './util/webCryptoAPI.js';
+import {
+  getMaxTopicsPerSubscribeEvent,
+  getWsKeyForTopicV1,
+  isPrivateChannel,
+  neverGuard,
+  safeTerminateWs,
+  WS_AUTH_ON_CONNECT_KEYS,
+  WS_BASE_URL_MAP,
+  WS_KEY_MAP,
+} from './util/websocket-util.js';
+import WsStore from './util/WsStore.js';
+import { WsConnectionStateEnum } from './util/WsStore.types.js';
+⋮----
+export type WsClientEvent =
+  | 'open'
+  | 'update'
+  | 'close'
+  | 'exception'
+  | 'reconnect'
+  | 'reconnected'
+  | 'response';
+⋮----
+interface WebsocketClientEvents {
+  /** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
+  open: (evt: { wsKey: WsKey; event: any }) => void;
+  /** Reconnecting a dropped connection */
+  reconnect: (evt: { wsKey: WsKey; event: any }) => void;
+  /** Successfully reconnected a connection that dropped */
+  reconnected: (evt: { wsKey: WsKey; event: any }) => void;
+  /** Connection closed */
+  close: (evt: { wsKey: WsKey; event: any }) => void;
+  /** Received reply to websocket command (e.g. after subscribing to topics) */
+  response: (response: any & { wsKey: WsKey }) => void;
+  /** Received data for topic */
+  update: (response: any & { wsKey: WsKey }) => void;
+  /** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
+  exception: (response: any & { wsKey: WsKey }) => void;
+  /** Confirmation that a connection successfully authenticated */
+  authenticated: (event: { wsKey: WsKey; event: any }) => void;
+}
+⋮----
+/** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
+⋮----
+/** Reconnecting a dropped connection */
+⋮----
+/** Successfully reconnected a connection that dropped */
+⋮----
+/** Connection closed */
+⋮----
+/** Received reply to websocket command (e.g. after subscribing to topics) */
+⋮----
+/** Received data for topic */
+⋮----
+/** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
+⋮----
+/** Confirmation that a connection successfully authenticated */
+⋮----
+// Type safety for on and emit handlers: https://stackoverflow.com/a/61609010/880837
+export declare interface WebsocketClientLegacyV1 {
+  on<U extends keyof WebsocketClientEvents>(
+    event: U,
+    listener: WebsocketClientEvents[U],
+  ): this;
+
+  emit<U extends keyof WebsocketClientEvents>(
+    event: U,
+    ...args: Parameters<WebsocketClientEvents[U]>
+  ): boolean;
+}
+⋮----
+on<U extends keyof WebsocketClientEvents>(
+    event: U,
+    listener: WebsocketClientEvents[U],
+  ): this;
+⋮----
+emit<U extends keyof WebsocketClientEvents>(
+    event: U,
+    ...args: Parameters<WebsocketClientEvents[U]>
+  ): boolean;
+⋮----
+/**
+ * @deprecated use WebsocketClientV2 instead
+ */
+export class WebsocketClientLegacyV1 extends EventEmitter
+⋮----
+constructor(
+    options: WSClientConfigurableOptions,
+    logger?: typeof DefaultLogger,
+)
+⋮----
+/**
+   * Subscribe to topics & track/persist them. They will be automatically resubscribed to if the connection drops/reconnects.
+   * @param wsTopics topic or list of topics
+   * @param isPrivateTopic optional - the library will try to detect private topics, you can use this to mark a topic as private (if the topic isn't recognised yet)
+   */
+public subscribe(
+    wsTopics: WsTopicSubscribeEventArgs[] | WsTopicSubscribeEventArgs,
+    isPrivateTopic?: boolean,
+)
+⋮----
+// Persist this topic to the expected topics list
+⋮----
+// if connected, send subscription request
+⋮----
+// if not authenticated, dont sub to private topics yet.
+// This'll happen automatically once authenticated
+⋮----
+// start connection process if it hasn't yet begun. Topics are automatically subscribed to on-connect
+⋮----
+/**
+   * Unsubscribe from topics & remove them from memory. They won't be re-subscribed to if the connection reconnects.
+   * @param wsTopics topic or list of topics
+   * @param isPrivateTopic optional - the library will try to detect private topics, you can use this to mark a topic as private (if the topic isn't recognised yet)
+   */
+public unsubscribe(
+    wsTopics: WsTopicSubscribeEventArgs[] | WsTopicSubscribeEventArgs,
+    isPrivateTopic?: boolean,
+)
+⋮----
+// unsubscribe request only necessary if active connection exists
+⋮----
+/** Get the WsStore that tracks websockets & topics */
+public getWsStore(): typeof this.wsStore
+⋮----
+public close(wsKey: WsKey, force?: boolean)
+⋮----
+public closeAll(force?: boolean)
+⋮----
+/**
+   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
+   */
+public connectAll(): Promise<WebSocket | undefined>[]
+⋮----
+/**
+   * Request connection to a specific websocket, instead of waiting for automatic connection.
+   */
+private async connect(wsKey: WsKey): Promise<WebSocket | undefined>
+⋮----
+const url = this.getWsUrl(wsKey); // + authParams;
+⋮----
+private parseWsError(context: string, error: any, wsKey: WsKey)
+⋮----
+private async getWsAuthSignature(
+    apiKey: string | undefined,
+    apiSecret: string | undefined,
+    apiPass: string | undefined,
+    recvWindow: number = 0,
+): Promise<
+⋮----
+/** Get a signature, build the auth request and send it */
+private async sendAuthRequest(wsKey: WsKey): Promise<void>
+⋮----
+// console.log('ws auth req', request);
+⋮----
+private reconnectWithDelay(wsKey: WsKey, connectionDelayMs: number)
+⋮----
+private ping(wsKey: WsKey)
+⋮----
+private clearTimers(wsKey: WsKey)
+⋮----
+// Send a ping at intervals
+private clearPingTimer(wsKey: WsKey)
+⋮----
+// Expect a pong within a time limit
+private clearPongTimer(wsKey: WsKey)
+⋮----
+/**
+   * @private Use the `subscribe(topics)` method to subscribe to topics. Send WS message to subscribe to topics.
+   */
+private requestSubscribeTopics(
+    wsKey: WsKey,
+    topics: WsTopicSubscribeEventArgs[],
+)
+⋮----
+/**
+   * @private Use the `unsubscribe(topics)` method to unsubscribe from topics. Send WS message to unsubscribe from topics.
+   */
+private requestUnsubscribeTopics(
+    wsKey: WsKey,
+    topics: WsTopicSubscribeEventArgs[],
+)
+⋮----
+public tryWsSend(wsKey: WsKey, wsMessage: string)
+⋮----
+private connectToWsUrl(url: string, wsKey: WsKey): WebSocket
+⋮----
+private async onWsOpen(event: WebSocket.Event, wsKey: WsKey)
+⋮----
+// Some websockets require an auth packet to be sent after opening the connection
+⋮----
+// Reconnect to topics known before it connected
+// Private topics will be resubscribed to once reconnected
+⋮----
+/** Handle subscription to private topics _after_ authentication successfully completes asynchronously */
+private onWsAuthenticated(wsKey: WsKey)
+⋮----
+private onWsMessage(event: unknown, wsKey: WsKey)
+⋮----
+// any message can clear the pong timer - wouldn't get a message if the ws wasn't working
+⋮----
+// messageType: typeof msg,
+// messageString: JSON.stringify(msg),
+⋮----
+// messageType: typeof msg,
+// messageString: JSON.stringify(msg),
+⋮----
+// fallback emit anyway
+⋮----
+private onWsClose(event: unknown, wsKey: WsKey)
+⋮----
+private getWs(wsKey: WsKey)
+⋮----
+private setWsState(wsKey: WsKey, state: WsConnectionStateEnum)
+⋮----
+private getWsUrl(wsKey: WsKey): string
+⋮----
+/**
+   * Subscribe to a topic
+   * @param instType instrument type (refer to API docs).
+   * @param topic topic name (e.g. "ticker").
+   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics.
+   *
+   * @deprecated use WebsocketClientV2 instead
+   */
+public subscribeTopic(
+    instType: BitgetInstType,
+    topic: WsTopic,
+    instId: string = 'default',
+)
+⋮----
+/**
+   * Unsubscribe from a topic
+   * @param instType instrument type (refer to API docs).
+   * @param topic topic name (e.g. "ticker").
+   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics to get all symbols.
+   *
+   * @deprecated use WebsocketClientV2 instead
+   */
+public unsubscribeTopic(
+    instType: BitgetInstType,
+    topic: WsTopic,
+    instId: string = 'default',
+)
 
 ================
 File: src/websocket-client-v3.ts
@@ -9539,242 +10254,153 @@ File: tsconfig.json
 }
 
 ================
-File: src/types/response/v3/account.ts
+File: src/websocket-api-client.ts
 ================
-// Account Management Response Types
-export interface AccountSymbolConfigV3 {
-  category: string;
-  symbol: string;
-  marginMode: string;
-  leverage: string;
+import { CancelOrderRequestV3 } from './types/request/v3/trade.js';
+import { CancelOrderResponseV3 } from './types/response/v3/trade.js';
+import { WSAPIResponse } from './types/websockets/ws-api.js';
+import { WSAPIPlaceOrderRequestV3 } from './types/websockets/ws-api-request.js';
+import { WSAPIPlaceOrderResponseV3 } from './types/websockets/ws-api-response.js';
+import {
+  BitgetInstTypeV3,
+  WSClientConfigurableOptions,
+} from './types/websockets/ws-general.js';
+import { DefaultLogger } from './util/logger.js';
+import { WS_KEY_MAP } from './util/websocket-util.js';
+import { WebsocketClientV3 } from './websocket-client-v3.js';
+⋮----
+/**
+ * Configurable options specific to only the REST-like WebsocketAPIClient
+ */
+export interface WSAPIClientConfigurableOptions {
+  /**
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
+  attachEventListeners: boolean;
 }
 ⋮----
-export interface AccountCoinConfigV3 {
-  coin: string;
-  leverage: string;
-}
+/**
+   * Default: true
+   *
+   * Attach default event listeners, which will console log any high level
+   * events (opened/reconnecting/reconnected/etc).
+   *
+   * If you disable this, you should set your own event listeners
+   * on the embedded WS Client `wsApiClient.getWSClient().on(....)`.
+   */
 ⋮----
-export interface AccountSettingsV3 {
-  assetMode: string;
-  holdMode: string;
-  symbolConfigList: AccountSymbolConfigV3[];
-  coinConfigList: AccountCoinConfigV3[];
-}
+/**
+ * This is a minimal Websocket API wrapper around the WebsocketClient.
+ *
+ * Note: You can also directly use the sendWSAPIRequest() method to make WS API calls, but some
+ * may find the below methods slightly more intuitive.
+ *
+ * Refer to the WS API promises example for a more detailed example on using sendWSAPIRequest() directly:
+ * https://github.com/tiagosiebler/bitget-api/blob/master/examples/V3/ws-api-trade-raw.ts
+ */
+export class WebsocketAPIClient
 ⋮----
-export interface AccountAssetV3 {
-  coin: string;
-  equity: string;
-  usdValue: string;
-  balance: string;
-  available: string;
-  debt: string;
-  locked: string;
-}
+constructor(
+    options?: WSClientConfigurableOptions &
+      Partial<WSAPIClientConfigurableOptions>,
+    logger?: DefaultLogger,
+)
 ⋮----
-export interface AccountAssetsV3 {
-  accountEquity: string;
-  usdtEquity: string;
-  btcEquity: string;
-  unrealisedPnl: string;
-  usdtUnrealisedPnl: string;
-  btcUnrealizedPnl: string;
-  effEquity: string;
-  mmr: string;
-  imr: string;
-  mgnRatio: string;
-  positionMgnRatio: string;
-  assets: AccountAssetV3[];
-}
+public getWSClient(): WebsocketClientV3
 ⋮----
-export interface ConvertRecordV3 {
-  fromCoin: string;
-  fromCoinSize: string;
-  toCoin: string;
-  toCoinSize: string;
-  price: string;
-  ts: string;
-}
+public setTimeOffsetMs(newOffset: number): void
 ⋮----
-export interface FinancialRecordV3 {
-  category: string;
-  id: string;
-  symbol: string;
-  coin: string;
-  type: string;
-  amount: string;
-  fee: string;
-  balance: string;
-  ts: string;
-}
+/*
+   * Bitget WebSocket API Methods
+   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel
+   */
 ⋮----
-export interface PaymentCoinV3 {
-  coin: string;
-  size: string;
-  amount: string;
-}
+/**
+   * Submit a new order
+   *
+   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel
+   *
+   * @returns
+   */
+submitNewOrder(
+    category: BitgetInstTypeV3,
+    params: WSAPIPlaceOrderRequestV3,
+): Promise<WSAPIResponse<[WSAPIPlaceOrderResponseV3], 'place-order'>>
 ⋮----
-export interface RepayableCoinV3 {
-  coin: string;
-  size: string;
-  amount: string;
-}
+/**
+   * Submit a new order
+   *
+   * https://www.bitget.com/api-doc/uta/websocket/private/Batch-Place-Order-Channel
+   *
+   * @returns
+   */
+placeBatchOrders(
+    category: BitgetInstTypeV3,
+    params: WSAPIPlaceOrderRequestV3[],
+): Promise<WSAPIResponse<WSAPIPlaceOrderResponseV3[], 'batch-place'>>
 ⋮----
-export interface RepayResponseV3 {
-  result: string;
-  repayAmount: string;
-}
+/*
+   * Bitget WebSocket API Methods
+   * https://www.bitget.com/api-doc/uta/websocket/private/Place-Order-Channel
+   */
 ⋮----
-// Sub-account Management Response Types
+/**
+   * Cancel Order
+   *
+   * https://www.bitget.com/api-doc/uta/websocket/private/Cancel-Order-Channel
+   *
+   * @returns
+   */
+cancelOrder(
+    category: BitgetInstTypeV3,
+    params: CancelOrderRequestV3,
+): Promise<WSAPIResponse<[CancelOrderResponseV3], 'cancel-order'>>
 ⋮----
-export interface CreateSubAccountApiKeyResponseV3 {
-  note: string;
-  apiKey: string;
-  secret: string;
-  type: string;
-  permissions: string[];
-  ips: string[];
-}
-export interface SubAccountApiKeyV3 {
-  apiKey: string;
-  note: string;
-  type: string;
-  permissions: string[];
-  ips: string[];
-  ts?: string;
-}
+/**
+   * Batch Cancel Order
+   *
+   * https://www.bitget.com/api-doc/uta/websocket/private/Batch-Cancel-Order-Channel
+   *
+   * @returns
+   */
+cancelBatchOrders(
+    category: BitgetInstTypeV3,
+    params: CancelOrderRequestV3[],
+): Promise<WSAPIResponse<CancelOrderResponseV3[], 'batch-cancel'>>
 ⋮----
-export interface UpdateSubAccountApiKeyResponseV3 {
-  note: string;
-  apiKey: string;
-  type: string;
-  permissions: string[];
-  ips: string[];
-}
+/**
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   * Private methods for handling some of the convenience/automation provided by the WS API Client
+   *
+   *
+   *
+   *
+   *
+   *
+   *
+   */
 ⋮----
-export interface CreateSubAccountResponseV3 {
-  username: string;
-  subUid: string;
-  status: string;
-  note: string;
-  createdTime: string;
-  updatedTime: string;
-}
+private setupDefaultEventListeners()
 ⋮----
-export interface SubAccountV3 {
-  subUid: string;
-  username: string;
-  status: string;
-  accountMode: string;
-  type: string;
-  note: string;
-  createdTime: string;
-  updatedTime: string;
-}
+/**
+       * General event handlers for monitoring the WebsocketClient
+       */
 ⋮----
-// Transfer Response Types
+// Blind JSON.stringify can fail on circular references
 ⋮----
-export interface TransferResponseV3 {
-  transferId: string;
-}
-⋮----
-export interface SubTransferRecordV3 {
-  transferId: string;
-  oldTransferId?: string;
-  fromType: string;
-  toType: string;
-  amount: string;
-  coin: string;
-  fromUserId: string;
-  toUserId: string;
-  status: string;
-  clientOid: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-export interface SubUnifiedAssetV3 {
-  coin: string;
-  equity: string;
-  usdValue: string;
-  balance: string;
-  available: string;
-  debt: string;
-  locked: string;
-}
-⋮----
-export interface SubUnifiedAssetV3 {
-  subUid: string;
-  cursor: string;
-  assets: SubUnifiedAssetV3[];
-}
-⋮----
-export interface GetFeeRateResponseV3 {
-  makerFeeRate: string;
-  takerFeeRate: string;
-}
-⋮----
-export interface FundingAssetV3 {
-  coin: string;
-  available: string;
-  frozen: string;
-  balance: string;
-}
-⋮----
-// Deposit Response Types
-⋮----
-export interface DepositAddressV3 {
-  address: string;
-  chain: string;
-  coin: string;
-  tag: string;
-  url: string;
-}
-⋮----
-export interface DepositRecordV3 {
-  orderId: string;
-  recordId: string;
-  coin: string;
-  type: 'deposit';
-  dest: 'on_chain' | 'internal_transfer';
-  size: string;
-  status: 'pending' | 'success' | 'fail';
-  fromAddress: string;
-  toAddress: string;
-  chain: string;
-  createdTime: string;
-  updatedTime: string;
-}
-⋮----
-// Withdraw Response Types
-⋮----
-export interface WithdrawResponseV3 {
-  orderId: string;
-  clientOid: string;
-}
-⋮----
-export interface WithdrawRecordV3 {
-  orderId: string;
-  clientOid: string;
-  recordId: string;
-  coin: string;
-  type: 'withdraw';
-  dest: 'on_chain' | 'internal_transfer';
-  size: string;
-  status: 'pending' | 'success' | 'fail';
-  fromAddress: string;
-  toAddress: string;
-  chain: string;
-  fee: string;
-  confirm: string;
-  tag: string;
-  createdTime: string;
-  updatedTime: string;
-}
-
-================
-File: .eslintrc.cjs
-================
-// 'no-unused-vars': ['warn'],
+// JSON.stringify({ ...data, target: 'WebSocket' }),
 
 ================
 File: src/types/websockets/ws-api.ts
@@ -9925,6 +10551,493 @@ File: src/index.ts
 
 
 ================
+File: .eslintrc.cjs
+================
+// 'no-unused-vars': ['warn'],
+
+================
+File: src/types/websockets/ws-general.ts
+================
+import { RestClientOptions } from '../../util/requestUtils.js';
+import { WS_KEY_MAP } from '../../util/websocket-util.js';
+import { FuturesProductTypeV2 } from '../request/shared.js';
+⋮----
+export type BitgetInstType = 'SP' | 'SPBL' | 'MC' | 'UMCBL' | 'DMCBL';
+export type BitgetInstTypeV2 = 'SPOT' | FuturesProductTypeV2;
+export type BitgetInstTypeV3 =
+  | 'UTA' // for account-level topics
+  | 'spot'
+  | 'usdt-futures'
+  | 'coin-futures'
+  | 'usdc-futures';
+⋮----
+| 'UTA' // for account-level topics
+⋮----
+/**
+ *
+ * V1  list of topics for WebSocket consumers
+ *
+ */
+⋮----
+export type WsPublicSpotTopic =
+  | 'ticker'
+  | 'candle1W'
+  | 'candle1D'
+  | 'candle12H'
+  | 'candle4H'
+  | 'candle1H'
+  | 'candle30m'
+  | 'candle15m'
+  | 'candle5m'
+  | 'candle1m'
+  | 'books'
+  | 'books5'
+  | 'trade';
+⋮----
+// Futures currently has the same public topics as spot
+export type WsPublicFuturesTopic = WsPublicSpotTopic;
+export type WsPrivateSpotTopic = 'account' | 'orders';
+⋮----
+export type WsPrivateFuturesTopic =
+  | 'account'
+  | 'positions'
+  | 'orders'
+  | 'ordersAlgo';
+⋮----
+export type WsPublicTopic = WsPublicSpotTopic | WsPublicFuturesTopic;
+⋮----
+export type WsPrivateTopic = WsPrivateSpotTopic | WsPrivateFuturesTopic;
+export type WsTopic = WsPublicTopic | WsPrivateTopic;
+⋮----
+/**
+ *
+ * V2 list of topics for WebSocket consumers
+ *
+ */
+⋮----
+export type WsPublicTopicV2 =
+  | 'index-price' // margin only
+  | 'ticker'
+  | 'candle1m'
+  | 'candle5m'
+  | 'candle15m'
+  | 'candle30m'
+  | 'candle1H'
+  | 'candle4H'
+  | 'candle6H'
+  | 'candle12H'
+  | 'candle1D'
+  | 'candle3D'
+  | 'candle1W'
+  | 'candle1M'
+  | 'candle6Hutc'
+  | 'candle12Hutc'
+  | 'candle1Dutc'
+  | 'candle3Dutc'
+  | 'candle1Wutc'
+  | 'candle1Mutc'
+  | 'trade'
+  | 'books'
+  | 'books1'
+  | 'books5'
+  | 'books15';
+⋮----
+| 'index-price' // margin only
+⋮----
+// Also update PRIVATE_TOPICS_V2 if this is updated
+export type WSPrivateTopicFuturesV2 =
+  | 'positions'
+  | 'orders-algo'
+  | 'positions-history';
+⋮----
+// Also update PRIVATE_TOPICS_V2 if this is updated
+export type WSPrivateTopicMarginV2 =
+  | 'orders-crossed'
+  | 'account-crossed'
+  | 'account-isolated'
+  | 'orders-isolated';
+⋮----
+// Also update PRIVATE_TOPICS_V2 if this is updated
+export type WsPrivateTopicV2 =
+  | 'account'
+  | 'orders'
+  | WSPrivateTopicFuturesV2
+  | WSPrivateTopicMarginV2;
+⋮----
+export type WsTopicV2 = WsPublicTopicV2 | WsPrivateTopicV2;
+⋮----
+/**
+ *
+ * V3 / UTA list of topics for WebSocket consumers
+ *
+ */
+export type WsPublicTopicV3 = 'ticker' | 'kline' | 'books' | 'publicTrade';
+// Also update PRIVATE_TOPICS_V3 if this is updated
+export type WsPrivateTopicV3 = 'account' | 'position' | 'fill' | 'order';
+export type WsTopicV3 = WsPublicTopicV3 | WsPrivateTopicV3;
+⋮----
+/** This is used to differentiate between each of the available websocket streams */
+export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
+⋮----
+/**
+ * Event args for subscribing/unsubscribing
+ */
+⋮----
+export interface WsTopicSubscribeEventArgs {
+  instType: BitgetInstType;
+  channel: WsTopic;
+  instId?: string;
+}
+⋮----
+export type WsTopicSubscribePublicArgsV2 = {
+  instType: BitgetInstTypeV2;
+  channel: WsPublicTopicV2;
+  /** The symbol, e.g. "BTCUSDT" */
+  instId: string;
+};
+⋮----
+/** The symbol, e.g. "BTCUSDT" */
+⋮----
+export type WsInstIdChannelsV2 =
+  | 'orders'
+  | WSPrivateTopicFuturesV2
+  | 'orders-crossed'
+  | 'orders-isolated';
+⋮----
+export type WsTopicSubscribePrivateInstIdArgsV2 = {
+  instType: BitgetInstTypeV2;
+  channel: WsInstIdChannelsV2;
+  /** The symbol, e.g. "BTCUSDT" */
+  instId?: string;
+};
+⋮----
+/** The symbol, e.g. "BTCUSDT" */
+⋮----
+export type WsCoinChannelsV2 =
+  | 'account'
+  | 'account-crossed'
+  | 'account-isolated';
+⋮----
+export type WsTopicSubscribePrivateCoinArgsV2 = {
+  instType: BitgetInstTypeV2;
+  channel: WsCoinChannelsV2;
+  coin: 'default' | string;
+};
+⋮----
+export type WsTopicSubscribePrivateArgsV2 =
+  | WsTopicSubscribePrivateInstIdArgsV2
+  | WsTopicSubscribePrivateCoinArgsV2;
+⋮----
+export type WsTopicSubscribeEventArgsV2 =
+  | WsTopicSubscribePublicArgsV2
+  | WsTopicSubscribePrivateArgsV2;
+⋮----
+/** General configuration for the WebsocketClient */
+export interface WSClientConfigurableOptions {
+  /** Your API key */
+  apiKey?: string;
+
+  /** Your API secret */
+  apiSecret?: string;
+
+  /** The passphrase you set when creating the API Key (NOT your account password) */
+  apiPass?: string;
+
+  /**
+   * Set to `true` to connect to Bitget's demo trading WebSockets:
+   *
+   * - V2: https://www.bitget.com/api-doc/common/demotrading/websocket
+   * - V3/UTA: https://www.bitget.com/api-doc/uta/guide#demo-trading
+   */
+  demoTrading?: boolean;
+
+  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+  recvWindow?: number;
+
+  // Disable ping/pong ws heartbeat mechanism (not recommended)
+  disableHeartbeat?: boolean;
+
+  /** How often to check if the connection is alive */
+  pingInterval?: number;
+
+  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+  pongTimeout?: number;
+
+  /** Delay in milliseconds before respawning the connection */
+  reconnectTimeout?: number;
+
+  requestOptions?: RestClientOptions;
+
+  wsOptions?: {
+    protocols?: string[];
+    agent?: any;
+  };
+
+  wsUrl?: string;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+}
+⋮----
+/** Your API key */
+⋮----
+/** Your API secret */
+⋮----
+/** The passphrase you set when creating the API Key (NOT your account password) */
+⋮----
+/**
+   * Set to `true` to connect to Bitget's demo trading WebSockets:
+   *
+   * - V2: https://www.bitget.com/api-doc/common/demotrading/websocket
+   * - V3/UTA: https://www.bitget.com/api-doc/uta/guide#demo-trading
+   */
+⋮----
+/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+⋮----
+// Disable ping/pong ws heartbeat mechanism (not recommended)
+⋮----
+/** How often to check if the connection is alive */
+⋮----
+/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+⋮----
+/** Delay in milliseconds before respawning the connection */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+export interface WebsocketClientOptions extends WSClientConfigurableOptions {
+  pingInterval: number;
+  pongTimeout: number;
+  reconnectTimeout: number;
+  recvWindow: number;
+  authPrivateConnectionsOnConnect: boolean;
+  authPrivateRequests: boolean;
+}
+
+================
+File: src/websocket-client-v2.ts
+================
+import {
+  WSOperation,
+  WSOperationLoginParams,
+  WsRequestOperationBitget,
+} from './types/websockets/ws-api.js';
+import { MessageEventLike } from './types/websockets/ws-events.js';
+import {
+  BitgetInstTypeV2,
+  WsKey,
+  WsTopicV2,
+} from './types/websockets/ws-general.js';
+import {
+  BaseWebsocketClient,
+  EmittableEvent,
+  MidflightWsRequestEvent,
+} from './util/BaseWSClient.js';
+import { isWsPong } from './util/requestUtils.js';
+import {
+  SignAlgorithm,
+  SignEncodeMethod,
+  signMessage,
+} from './util/webCryptoAPI.js';
+import {
+  getMaxTopicsPerSubscribeEvent,
+  getNormalisedTopicRequests,
+  getWsUrl,
+  isPrivateChannel,
+  WS_AUTH_ON_CONNECT_KEYS,
+  WS_KEY_MAP,
+  WsTopicRequest,
+} from './util/websocket-util.js';
+import { WSConnectedResult } from './util/WsStore.types.js';
+⋮----
+export class WebsocketClientV2 extends BaseWebsocketClient<
+⋮----
+WsRequestOperationBitget<object> // subscribe requests have an "args" parameter with an object within
+⋮----
+/**
+   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
+   */
+public connectAll(): Promise<WSConnectedResult | undefined>[]
+⋮----
+/** Some private channels use `coin` instead of `instId`. This method handles building the sub/unsub request */
+private getSubRequest(
+    instType: BitgetInstTypeV2,
+    topic: WsTopicV2,
+    coin: string = 'default',
+): WsTopicRequest<string>
+⋮----
+/**
+   * Subscribe to a topic
+   * @param instType instrument type (refer to API docs).
+   * @param topic topic name (e.g. "ticker").
+   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics.
+   */
+public subscribeTopic(
+    instType: BitgetInstTypeV2,
+    topic: WsTopicV2,
+    coin: string = 'default',
+)
+⋮----
+/**
+   * Unsubscribe from a topic
+   * @param instType instrument type (refer to API docs).
+   * @param topic topic name (e.g. "ticker").
+   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics to get all symbols.
+   */
+public unsubscribeTopic(
+    instType: BitgetInstTypeV2,
+    topic: WsTopicV2,
+    coin: string = 'default',
+)
+⋮----
+/**
+   * Request subscription to one or more topics. Pass topics as either an array of strings,
+   * or array of objects (if the topic has parameters).
+   *
+   * Objects should be formatted as {topic: string, params: object, category: CategoryV5}.
+   *
+   * - Subscriptions are automatically routed to the correct websocket connection.
+   * - Authentication/connection is automatic.
+   * - Resubscribe after network issues is automatic.
+   *
+   * Call `unsubscribe(topics)` to remove topics
+   */
+public subscribe(
+    requests:
+      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)
+      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)[],
+    wsKey: WsKey,
+): Promise<unknown>
+⋮----
+/**
+   * Unsubscribe from one or more topics. Similar to subscribe() but in reverse.
+   *
+   * - Requests are automatically routed to the correct websocket connection.
+   * - These topics will be removed from the topic cache, so they won't be subscribed to again.
+   */
+public unsubscribe(
+    requests:
+      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)
+      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)[],
+    wsKey: WsKey,
+)
+⋮----
+/**
+   *
+   *
+   * Internal methods required to integrate with the BaseWSClient
+   *
+   *
+   */
+⋮----
+protected sendPingEvent(wsKey: WsKey): void
+⋮----
+protected sendPongEvent(wsKey: WsKey): void
+⋮----
+protected isWsPing(data: any): boolean
+⋮----
+protected isWsPong(data: any): boolean
+⋮----
+protected isPrivateTopicRequest(
+    _request: WsTopicRequest<string>,
+    wsKey: WsKey,
+): boolean
+⋮----
+protected getPrivateWSKeys(): WsKey[]
+⋮----
+protected isAuthOnConnectWsKey(wsKey: WsKey): boolean
+⋮----
+protected async getWsUrl(wsKey: WsKey): Promise<string>
+⋮----
+protected getMaxTopicsPerSubscribeEvent(wsKey: WsKey): number | null
+⋮----
+/**
+   * @returns one or more correctly structured request events for performing a operations over WS. This can vary per exchange spec.
+   */
+protected async getWsRequestEvents(
+    operation: WSOperation,
+    requests: WsTopicRequest<string, object>[],
+): Promise<MidflightWsRequestEvent<WsRequestOperationBitget<object>>[]>
+⋮----
+// Previously used to track topics in a request. Keeping this for subscribe/unsubscribe requests, no need for incremental values
+⋮----
+/**
+      {
+        "op":"subscribe",
+        "args":[
+            {
+                "instType":"SPOT",
+                "channel":"ticker",
+                "instId":"BTCUSDT"
+            },
+            {
+                "instType":"SPOT",
+                "channel":"candle5m",
+                "instId":"BTCUSDT"
+            }
+        ]
+      }
+    */
+⋮----
+// const request = {
+//   topic: 'ticker',
+//   payload: { instType: 'SPOT', instId: 'BTCUSDT' },
+// };
+// becomes:
+// const request = {
+//   channel: 'ticker',
+//   instType: 'SPOT',
+//   instId: 'BTCUSDT',
+// };
+⋮----
+private async getWsAuthSignature(
+    wsKey: WsKey,
+): Promise<
+⋮----
+private async signMessage(
+    paramsStr: string,
+    secret: string,
+    method: SignEncodeMethod,
+    algorithm: SignAlgorithm,
+): Promise<string>
+⋮----
+protected async getWsAuthRequestEvent(
+    wsKey: WsKey,
+): Promise<WsRequestOperationBitget<WSOperationLoginParams>>
+⋮----
+/**
+   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
+   */
+protected resolveEmittableEvents(
+    wsKey: WsKey,
+    event: MessageEventLike,
+): EmittableEvent[]
+⋮----
+// v2 event processing
+⋮----
+// v2 authentication event
+⋮----
+// messageType: typeof msg,
+// messageString: JSON.stringify(msg),
+⋮----
+// messageType: typeof msg,
+// messageString: JSON.stringify(msg),
+⋮----
+// fallback emit anyway
+⋮----
+/**
+   * @deprecrated not supported by Bitget's V2 API offering
+   */
+async sendWSAPIRequest(): Promise<unknown>
+
+================
 File: src/rest-client-v2.ts
 ================
 import { FuturesProductTypeV2, MarginType } from './types/request/shared.js';
@@ -9932,7 +11045,10 @@ import {
   CreateSubAccountApiKeyRequestV2,
   GetAllSubDepositWithdrawalRequestV2,
   GetBrokerCommissionsRequestV2,
+  GetBrokerOrderCommissionRequestV2,
+  GetBrokerRebateInfoRequestV2,
   GetBrokerSubaccountsRequestV2,
+  GetBrokerTotalCommissionRequestV2,
   GetBrokerTradeVolumeRequestV2,
   GetSubAccountsRequestV2,
   ModifySubAccountApiKeyRequestV2,
@@ -10016,6 +11132,9 @@ import {
   FuturesHistoricalPositionsRequestV2,
   FuturesHistoricTradesRequestV2,
   FuturesInterestHistoryRequestV2,
+  FuturesIsolatedSymbolsRequestV2,
+  FuturesLiquidationPriceRequestV2,
+  FuturesMaxOpenRequestV2,
   FuturesMergeDepthRequestV2,
   FuturesModifyOrderRequestV2,
   FuturesModifyPlanOrderRequestV2,
@@ -10079,11 +11198,14 @@ import { APIResponse } from './types/response/v1/shared.js';
 import {
   AllSubDepositWithdrawalRecordV2,
   BrokerCommissionV2,
+  BrokerOrderCommissionV2,
+  BrokerRebateInfoV2,
   BrokerSubaccountFutureAssetV2,
   BrokerSubaccountInfoV2,
   BrokerSubaccountSpotAssetV2,
   BrokerSubaccountV2,
   BrokerSubaccountWithdrawalV2,
+  BrokerTotalCommissionV2,
   BrokerTradeVolumeV2,
   CreateSubaccountApiKeyResponseV2,
   CreateSubaccountDepositAddressV2,
@@ -10193,6 +11315,9 @@ import {
   FuturesHistoryPositionV2,
   FuturesInterestExchangeRateV2,
   FuturesInterestHistoryV2,
+  FuturesIsolatedSymbolV2,
+  FuturesLiquidationPriceV2,
+  FuturesMaxOpenV2,
   FuturesMergeDepthV2,
   FuturesOpenInterestV2,
   FuturesOpenOrderV2,
@@ -10984,21 +12109,25 @@ getFuturesHistoricFundingRates(params: {
 }): Promise<APIResponse<FuturesHistoricalFundingRateV2[]>>
 ⋮----
 getFuturesCurrentFundingRate(params: {
-    symbol: string;
+    symbol?: string;
     productType: FuturesProductTypeV2;
   }): Promise<
     APIResponse<
       {
         symbol: string;
-        fundingRate: string;
-        fundingRateInterval: string;
-        nextUpdate: string;
+        fundingRate: string; // '0.0001';
+        fundingRateInterval: string; // hours, example: '1' | '2' | '4' | '8';
+        nextUpdate: string; // timestamp in milliseconds
         minFundingRate: string;
         maxFundingRate: string;
       }[]
     >
   > {
     return this.get('/api/v2/mix/market/current-fund-rate', params);
+⋮----
+fundingRate: string; // '0.0001';
+fundingRateInterval: string; // hours, example: '1' | '2' | '4' | '8';
+nextUpdate: string; // timestamp in milliseconds
 ⋮----
 getFuturesContractConfig(params: {
     symbol?: string;
@@ -11116,6 +12245,36 @@ getSwitchUnionUsdt(): Promise<APIResponse<UnionSwitchUsdtV2>>
 unionConvert(
     params: UnionConvertRequestV2,
 ): Promise<APIResponse<UnionConvertV2>>
+⋮----
+/**
+   * Get Max Openable Quantity
+   *
+   * - Rate limit: 20 req/sec/UID
+   * - Get Max Openable Quantity
+   */
+getFuturesMaxOpenableQuantity(
+    params: FuturesMaxOpenRequestV2,
+): Promise<APIResponse<FuturesMaxOpenV2>>
+⋮----
+/**
+   * Get Liquidation Price
+   *
+   * - Rate limit: 20 req/sec/UID
+   * - Get Liquidation Price
+   */
+getFuturesLiquidationPrice(
+    params: FuturesLiquidationPriceRequestV2,
+): Promise<APIResponse<FuturesLiquidationPriceV2>>
+⋮----
+/**
+   * Get Isolated Symbols
+   *
+   * - Rate limits: 10 time/1s (uid)
+   * - Retrieve trading pairs with isolated margin mode under the account.
+   */
+getFuturesIsolatedSymbols(
+    params: FuturesIsolatedSymbolsRequestV2,
+): Promise<APIResponse<FuturesIsolatedSymbolV2[]>>
 ⋮----
 /**
    *
@@ -11493,6 +12652,55 @@ getBrokerCommissions(
 getBrokerTradeVolume(
     params?: GetBrokerTradeVolumeRequestV2,
 ): Promise<APIResponse<BrokerTradeVolumeV2[]>>
+⋮----
+/**
+   * Get Total Commission
+   *
+   * - Rate limit: 20 req/sec/UID
+   * - Data retention: 365 days
+   * - Historical data available from: 2025/6/1
+   * - Data granularity: daily
+   * - Data update granularity: daily, previous day's data is updated on the current day
+   * - Time zone: UTC+8
+   * - startTime and endTime should either both be set or both left unset
+   * - This API supports retrieving data within the past 365 days (data is available starting from 2025/6/1 at the earliest)
+   * - If startTime and endTime are not set in the request, the default returned information will be for yesterday (00:00-23:59 UTC+8)
+   * - Data update frequency: T+1 (UTC+8)
+   */
+getBrokerTotalCommission(
+    params?: GetBrokerTotalCommissionRequestV2,
+): Promise<APIResponse<BrokerTotalCommissionV2[]>>
+⋮----
+/**
+   * Get Order Commission
+   *
+   * - Rate limit: 20 req/sec/UID
+   * - Data storage: 30 days
+   * - Historical data backtracking: 2025/9/1
+   * - Data granularity: daily
+   * - Data update frequency: daily, previous day's data is updated on the current day
+   * - Time zone: UTC+8
+   * - startTime and endTime should either both be set or both not set
+   * - The maximum time span supported for startTime and endTime is 30 days
+   * - This API supports retrieving data within the past 30 days
+   * - If startTime and endTime are not set in the request, the default return will be information for yesterday (00:00-23:59 UTC+8)
+   * - This API data is updated on a T+1 basis
+   * - Transaction details only show those marked with broker channel id
+   */
+getBrokerOrderCommission(
+    params?: GetBrokerOrderCommissionRequestV2,
+): Promise<APIResponse<BrokerOrderCommissionV2>>
+⋮----
+/**
+   * Get Rebate Info
+   *
+   * - Rate limit: 20 req/sec/UID
+   * - Data retention: 30 days
+   * - Real-time data
+   */
+getBrokerRebateInfo(
+    params: GetBrokerRebateInfoRequestV2,
+): Promise<APIResponse<BrokerRebateInfoV2>>
 ⋮----
 /**
    *
@@ -12303,748 +13511,919 @@ getLoanLiquidationRecords(
 ): Promise<APIResponse<EarnLoanLiquidationRecordsV2[]>>
 
 ================
-File: src/websocket-client-legacy-v1.ts
-================
-/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging */
-import { EventEmitter } from 'events';
-import WebSocket from 'isomorphic-ws';
-⋮----
-import {
-  BitgetInstType,
-  WebsocketClientOptions,
-  WSClientConfigurableOptions,
-  WsKey,
-  WsTopic,
-  WsTopicSubscribeEventArgs,
-} from './types/websockets/ws-general.js';
-import { DefaultLogger } from './util/logger.js';
-import { isWsPong } from './util/requestUtils.js';
-import { signMessage } from './util/webCryptoAPI.js';
-import {
-  getMaxTopicsPerSubscribeEvent,
-  getWsKeyForTopicV1,
-  isPrivateChannel,
-  neverGuard,
-  safeTerminateWs,
-  WS_AUTH_ON_CONNECT_KEYS,
-  WS_BASE_URL_MAP,
-  WS_KEY_MAP,
-} from './util/websocket-util.js';
-import WsStore from './util/WsStore.js';
-import { WsConnectionStateEnum } from './util/WsStore.types.js';
-⋮----
-export type WsClientEvent =
-  | 'open'
-  | 'update'
-  | 'close'
-  | 'exception'
-  | 'reconnect'
-  | 'reconnected'
-  | 'response';
-⋮----
-interface WebsocketClientEvents {
-  /** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
-  open: (evt: { wsKey: WsKey; event: any }) => void;
-  /** Reconnecting a dropped connection */
-  reconnect: (evt: { wsKey: WsKey; event: any }) => void;
-  /** Successfully reconnected a connection that dropped */
-  reconnected: (evt: { wsKey: WsKey; event: any }) => void;
-  /** Connection closed */
-  close: (evt: { wsKey: WsKey; event: any }) => void;
-  /** Received reply to websocket command (e.g. after subscribing to topics) */
-  response: (response: any & { wsKey: WsKey }) => void;
-  /** Received data for topic */
-  update: (response: any & { wsKey: WsKey }) => void;
-  /** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
-  exception: (response: any & { wsKey: WsKey }) => void;
-  /** Confirmation that a connection successfully authenticated */
-  authenticated: (event: { wsKey: WsKey; event: any }) => void;
-}
-⋮----
-/** Connection opened. If this connection was previously opened and reconnected, expect the reconnected event instead */
-⋮----
-/** Reconnecting a dropped connection */
-⋮----
-/** Successfully reconnected a connection that dropped */
-⋮----
-/** Connection closed */
-⋮----
-/** Received reply to websocket command (e.g. after subscribing to topics) */
-⋮----
-/** Received data for topic */
-⋮----
-/** Exception from ws client OR custom listeners (e.g. if you throw inside your event handler) */
-⋮----
-/** Confirmation that a connection successfully authenticated */
-⋮----
-// Type safety for on and emit handlers: https://stackoverflow.com/a/61609010/880837
-export declare interface WebsocketClientLegacyV1 {
-  on<U extends keyof WebsocketClientEvents>(
-    event: U,
-    listener: WebsocketClientEvents[U],
-  ): this;
-
-  emit<U extends keyof WebsocketClientEvents>(
-    event: U,
-    ...args: Parameters<WebsocketClientEvents[U]>
-  ): boolean;
-}
-⋮----
-on<U extends keyof WebsocketClientEvents>(
-    event: U,
-    listener: WebsocketClientEvents[U],
-  ): this;
-⋮----
-emit<U extends keyof WebsocketClientEvents>(
-    event: U,
-    ...args: Parameters<WebsocketClientEvents[U]>
-  ): boolean;
-⋮----
-/**
- * @deprecated use WebsocketClientV2 instead
- */
-export class WebsocketClientLegacyV1 extends EventEmitter
-⋮----
-constructor(
-    options: WSClientConfigurableOptions,
-    logger?: typeof DefaultLogger,
-)
-⋮----
-/**
-   * Subscribe to topics & track/persist them. They will be automatically resubscribed to if the connection drops/reconnects.
-   * @param wsTopics topic or list of topics
-   * @param isPrivateTopic optional - the library will try to detect private topics, you can use this to mark a topic as private (if the topic isn't recognised yet)
-   */
-public subscribe(
-    wsTopics: WsTopicSubscribeEventArgs[] | WsTopicSubscribeEventArgs,
-    isPrivateTopic?: boolean,
-)
-⋮----
-// Persist this topic to the expected topics list
-⋮----
-// if connected, send subscription request
-⋮----
-// if not authenticated, dont sub to private topics yet.
-// This'll happen automatically once authenticated
-⋮----
-// start connection process if it hasn't yet begun. Topics are automatically subscribed to on-connect
-⋮----
-/**
-   * Unsubscribe from topics & remove them from memory. They won't be re-subscribed to if the connection reconnects.
-   * @param wsTopics topic or list of topics
-   * @param isPrivateTopic optional - the library will try to detect private topics, you can use this to mark a topic as private (if the topic isn't recognised yet)
-   */
-public unsubscribe(
-    wsTopics: WsTopicSubscribeEventArgs[] | WsTopicSubscribeEventArgs,
-    isPrivateTopic?: boolean,
-)
-⋮----
-// unsubscribe request only necessary if active connection exists
-⋮----
-/** Get the WsStore that tracks websockets & topics */
-public getWsStore(): typeof this.wsStore
-⋮----
-public close(wsKey: WsKey, force?: boolean)
-⋮----
-public closeAll(force?: boolean)
-⋮----
-/**
-   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
-   */
-public connectAll(): Promise<WebSocket | undefined>[]
-⋮----
-/**
-   * Request connection to a specific websocket, instead of waiting for automatic connection.
-   */
-private async connect(wsKey: WsKey): Promise<WebSocket | undefined>
-⋮----
-const url = this.getWsUrl(wsKey); // + authParams;
-⋮----
-private parseWsError(context: string, error: any, wsKey: WsKey)
-⋮----
-private async getWsAuthSignature(
-    apiKey: string | undefined,
-    apiSecret: string | undefined,
-    apiPass: string | undefined,
-    recvWindow: number = 0,
-): Promise<
-⋮----
-/** Get a signature, build the auth request and send it */
-private async sendAuthRequest(wsKey: WsKey): Promise<void>
-⋮----
-// console.log('ws auth req', request);
-⋮----
-private reconnectWithDelay(wsKey: WsKey, connectionDelayMs: number)
-⋮----
-private ping(wsKey: WsKey)
-⋮----
-private clearTimers(wsKey: WsKey)
-⋮----
-// Send a ping at intervals
-private clearPingTimer(wsKey: WsKey)
-⋮----
-// Expect a pong within a time limit
-private clearPongTimer(wsKey: WsKey)
-⋮----
-/**
-   * @private Use the `subscribe(topics)` method to subscribe to topics. Send WS message to subscribe to topics.
-   */
-private requestSubscribeTopics(
-    wsKey: WsKey,
-    topics: WsTopicSubscribeEventArgs[],
-)
-⋮----
-/**
-   * @private Use the `unsubscribe(topics)` method to unsubscribe from topics. Send WS message to unsubscribe from topics.
-   */
-private requestUnsubscribeTopics(
-    wsKey: WsKey,
-    topics: WsTopicSubscribeEventArgs[],
-)
-⋮----
-public tryWsSend(wsKey: WsKey, wsMessage: string)
-⋮----
-private connectToWsUrl(url: string, wsKey: WsKey): WebSocket
-⋮----
-private async onWsOpen(event: WebSocket.Event, wsKey: WsKey)
-⋮----
-// Some websockets require an auth packet to be sent after opening the connection
-⋮----
-// Reconnect to topics known before it connected
-// Private topics will be resubscribed to once reconnected
-⋮----
-/** Handle subscription to private topics _after_ authentication successfully completes asynchronously */
-private onWsAuthenticated(wsKey: WsKey)
-⋮----
-private onWsMessage(event: unknown, wsKey: WsKey)
-⋮----
-// any message can clear the pong timer - wouldn't get a message if the ws wasn't working
-⋮----
-// messageType: typeof msg,
-// messageString: JSON.stringify(msg),
-⋮----
-// messageType: typeof msg,
-// messageString: JSON.stringify(msg),
-⋮----
-// fallback emit anyway
-⋮----
-private onWsClose(event: unknown, wsKey: WsKey)
-⋮----
-private getWs(wsKey: WsKey)
-⋮----
-private setWsState(wsKey: WsKey, state: WsConnectionStateEnum)
-⋮----
-private getWsUrl(wsKey: WsKey): string
-⋮----
-/**
-   * Subscribe to a topic
-   * @param instType instrument type (refer to API docs).
-   * @param topic topic name (e.g. "ticker").
-   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics.
-   *
-   * @deprecated use WebsocketClientV2 instead
-   */
-public subscribeTopic(
-    instType: BitgetInstType,
-    topic: WsTopic,
-    instId: string = 'default',
-)
-⋮----
-/**
-   * Unsubscribe from a topic
-   * @param instType instrument type (refer to API docs).
-   * @param topic topic name (e.g. "ticker").
-   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics to get all symbols.
-   *
-   * @deprecated use WebsocketClientV2 instead
-   */
-public unsubscribeTopic(
-    instType: BitgetInstType,
-    topic: WsTopic,
-    instId: string = 'default',
-)
-
-================
-File: src/types/websockets/ws-general.ts
-================
-import { RestClientOptions } from '../../util/requestUtils.js';
-import { WS_KEY_MAP } from '../../util/websocket-util.js';
-import { FuturesProductTypeV2 } from '../request/shared.js';
-⋮----
-export type BitgetInstType = 'SP' | 'SPBL' | 'MC' | 'UMCBL' | 'DMCBL';
-export type BitgetInstTypeV2 = 'SPOT' | FuturesProductTypeV2;
-export type BitgetInstTypeV3 =
-  | 'UTA' // for account-level topics
-  | 'spot'
-  | 'usdt-futures'
-  | 'coin-futures'
-  | 'usdc-futures';
-⋮----
-| 'UTA' // for account-level topics
-⋮----
-/**
- *
- * V1  list of topics for WebSocket consumers
- *
- */
-⋮----
-export type WsPublicSpotTopic =
-  | 'ticker'
-  | 'candle1W'
-  | 'candle1D'
-  | 'candle12H'
-  | 'candle4H'
-  | 'candle1H'
-  | 'candle30m'
-  | 'candle15m'
-  | 'candle5m'
-  | 'candle1m'
-  | 'books'
-  | 'books5'
-  | 'trade';
-⋮----
-// Futures currently has the same public topics as spot
-export type WsPublicFuturesTopic = WsPublicSpotTopic;
-export type WsPrivateSpotTopic = 'account' | 'orders';
-⋮----
-export type WsPrivateFuturesTopic =
-  | 'account'
-  | 'positions'
-  | 'orders'
-  | 'ordersAlgo';
-⋮----
-export type WsPublicTopic = WsPublicSpotTopic | WsPublicFuturesTopic;
-⋮----
-export type WsPrivateTopic = WsPrivateSpotTopic | WsPrivateFuturesTopic;
-export type WsTopic = WsPublicTopic | WsPrivateTopic;
-⋮----
-/**
- *
- * V2 list of topics for WebSocket consumers
- *
- */
-⋮----
-export type WsPublicTopicV2 =
-  | 'index-price' // margin only
-  | 'ticker'
-  | 'candle1m'
-  | 'candle5m'
-  | 'candle15m'
-  | 'candle30m'
-  | 'candle1H'
-  | 'candle4H'
-  | 'candle6H'
-  | 'candle12H'
-  | 'candle1D'
-  | 'candle3D'
-  | 'candle1W'
-  | 'candle1M'
-  | 'candle6Hutc'
-  | 'candle12Hutc'
-  | 'candle1Dutc'
-  | 'candle3Dutc'
-  | 'candle1Wutc'
-  | 'candle1Mutc'
-  | 'trade'
-  | 'books'
-  | 'books1'
-  | 'books5'
-  | 'books15';
-⋮----
-| 'index-price' // margin only
-⋮----
-// Also update PRIVATE_TOPICS_V2 if this is updated
-export type WSPrivateTopicFuturesV2 =
-  | 'positions'
-  | 'orders-algo'
-  | 'positions-history';
-⋮----
-// Also update PRIVATE_TOPICS_V2 if this is updated
-export type WSPrivateTopicMarginV2 =
-  | 'orders-crossed'
-  | 'account-crossed'
-  | 'account-isolated'
-  | 'orders-isolated';
-⋮----
-// Also update PRIVATE_TOPICS_V2 if this is updated
-export type WsPrivateTopicV2 =
-  | 'account'
-  | 'orders'
-  | WSPrivateTopicFuturesV2
-  | WSPrivateTopicMarginV2;
-⋮----
-export type WsTopicV2 = WsPublicTopicV2 | WsPrivateTopicV2;
-⋮----
-/**
- *
- * V3 / UTA list of topics for WebSocket consumers
- *
- */
-export type WsPublicTopicV3 = 'ticker' | 'kline' | 'books' | 'publicTrade';
-// Also update PRIVATE_TOPICS_V3 if this is updated
-export type WsPrivateTopicV3 = 'account' | 'position' | 'fill' | 'order';
-export type WsTopicV3 = WsPublicTopicV3 | WsPrivateTopicV3;
-⋮----
-/** This is used to differentiate between each of the available websocket streams */
-export type WsKey = (typeof WS_KEY_MAP)[keyof typeof WS_KEY_MAP];
-⋮----
-/**
- * Event args for subscribing/unsubscribing
- */
-⋮----
-export interface WsTopicSubscribeEventArgs {
-  instType: BitgetInstType;
-  channel: WsTopic;
-  instId?: string;
-}
-⋮----
-export type WsTopicSubscribePublicArgsV2 = {
-  instType: BitgetInstTypeV2;
-  channel: WsPublicTopicV2;
-  /** The symbol, e.g. "BTCUSDT" */
-  instId: string;
-};
-⋮----
-/** The symbol, e.g. "BTCUSDT" */
-⋮----
-export type WsInstIdChannelsV2 =
-  | 'orders'
-  | WSPrivateTopicFuturesV2
-  | 'orders-crossed'
-  | 'orders-isolated';
-⋮----
-export type WsTopicSubscribePrivateInstIdArgsV2 = {
-  instType: BitgetInstTypeV2;
-  channel: WsInstIdChannelsV2;
-  /** The symbol, e.g. "BTCUSDT" */
-  instId?: string;
-};
-⋮----
-/** The symbol, e.g. "BTCUSDT" */
-⋮----
-export type WsCoinChannelsV2 =
-  | 'account'
-  | 'account-crossed'
-  | 'account-isolated';
-⋮----
-export type WsTopicSubscribePrivateCoinArgsV2 = {
-  instType: BitgetInstTypeV2;
-  channel: WsCoinChannelsV2;
-  coin: 'default' | string;
-};
-⋮----
-export type WsTopicSubscribePrivateArgsV2 =
-  | WsTopicSubscribePrivateInstIdArgsV2
-  | WsTopicSubscribePrivateCoinArgsV2;
-⋮----
-export type WsTopicSubscribeEventArgsV2 =
-  | WsTopicSubscribePublicArgsV2
-  | WsTopicSubscribePrivateArgsV2;
-⋮----
-/** General configuration for the WebsocketClient */
-export interface WSClientConfigurableOptions {
-  /** Your API key */
-  apiKey?: string;
-
-  /** Your API secret */
-  apiSecret?: string;
-
-  /** The passphrase you set when creating the API Key (NOT your account password) */
-  apiPass?: string;
-
-  /**
-   * Set to `true` to connect to Bitget's demo trading WebSockets:
-   *
-   * - V2: https://www.bitget.com/api-doc/common/demotrading/websocket
-   * - V3/UTA: https://www.bitget.com/api-doc/uta/guide#demo-trading
-   */
-  demoTrading?: boolean;
-
-  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-  recvWindow?: number;
-
-  // Disable ping/pong ws heartbeat mechanism (not recommended)
-  disableHeartbeat?: boolean;
-
-  /** How often to check if the connection is alive */
-  pingInterval?: number;
-
-  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-  pongTimeout?: number;
-
-  /** Delay in milliseconds before respawning the connection */
-  reconnectTimeout?: number;
-
-  requestOptions?: RestClientOptions;
-
-  wsOptions?: {
-    protocols?: string[];
-    agent?: any;
-  };
-
-  wsUrl?: string;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-}
-⋮----
-/** Your API key */
-⋮----
-/** Your API secret */
-⋮----
-/** The passphrase you set when creating the API Key (NOT your account password) */
-⋮----
-/**
-   * Set to `true` to connect to Bitget's demo trading WebSockets:
-   *
-   * - V2: https://www.bitget.com/api-doc/common/demotrading/websocket
-   * - V3/UTA: https://www.bitget.com/api-doc/uta/guide#demo-trading
-   */
-⋮----
-/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-⋮----
-// Disable ping/pong ws heartbeat mechanism (not recommended)
-⋮----
-/** How often to check if the connection is alive */
-⋮----
-/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-⋮----
-/** Delay in milliseconds before respawning the connection */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-export interface WebsocketClientOptions extends WSClientConfigurableOptions {
-  pingInterval: number;
-  pongTimeout: number;
-  reconnectTimeout: number;
-  recvWindow: number;
-  authPrivateConnectionsOnConnect: boolean;
-  authPrivateRequests: boolean;
-}
-
-================
-File: src/websocket-client-v2.ts
+File: src/rest-client-v3.ts
 ================
 import {
-  WSOperation,
-  WSOperationLoginParams,
-  WsRequestOperationBitget,
-} from './types/websockets/ws-api.js';
-import { MessageEventLike } from './types/websockets/ws-events.js';
+  CreateSubAccountApiKeyRequestV3,
+  CreateSubAccountRequestV3,
+  DeleteSubAccountApiKeyRequestV3,
+  FreezeSubAccountRequestV3,
+  GetConvertRecordsRequestV3,
+  GetDepositAddressRequestV3,
+  GetDepositRecordsRequestV3,
+  GetFeeRateRequestV3,
+  GetFinancialRecordsRequestV3,
+  GetFundingAssetsRequestV3,
+  GetMaxTransferableRequestV3,
+  GetOpenInterestLimitRequestV3,
+  GetSubAccountApiKeysRequestV3,
+  GetSubAccountListRequestV3,
+  GetSubDepositAddressRequestV3,
+  GetSubDepositRecordsRequestV3,
+  GetSubTransferRecordsRequestV3,
+  GetSubUnifiedAssetsRequestV3,
+  GetTaxRecordsRequestV3,
+  GetTransferableCoinsRequestV3,
+  GetWithdrawRecordsRequestV3,
+  RepayRequestV3,
+  SetDepositAccountRequestV3,
+  SetLeverageRequestV3,
+  SubAccountTransferRequestV3,
+  SwitchDeductRequestV3,
+  TransferRequestV3,
+  UpdateSubAccountApiKeyRequestV3,
+  WithdrawRequestV3,
+} from './types/request/v3/account.js';
 import {
-  BitgetInstTypeV2,
-  WsKey,
-  WsTopicV2,
-} from './types/websockets/ws-general.js';
+  BindUidRequestV3,
+  GetEnsureCoinsRequestV3,
+  GetLoanOrderRequestV3,
+  GetLTVConvertRequestV3,
+  GetProductInfosRequestV3,
+  GetRepaidHistoryRequestV3,
+  GetSymbolsRequestV3,
+  GetTransferedRequestV3,
+} from './types/request/v3/loan.js';
 import {
-  BaseWebsocketClient,
-  EmittableEvent,
-  MidflightWsRequestEvent,
-} from './util/BaseWSClient.js';
-import { isWsPong } from './util/requestUtils.js';
+  GetCandlesRequestV3,
+  GetContractsOiRequestV3,
+  GetCurrentFundingRateRequestV3,
+  GetHistoryCandlesRequestV3,
+  GetHistoryFundingRateRequestV3,
+  GetInstrumentsRequestV3,
+  GetMarginLoansRequestV3,
+  GetOpenInterestRequestV3,
+  GetOrderBookRequestV3,
+  GetPositionTierRequestV3,
+  GetPublicFillsRequestV3,
+  GetRiskReserveRequestV3,
+  GetTickersRequestV3,
+} from './types/request/v3/public.js';
 import {
-  SignAlgorithm,
-  SignEncodeMethod,
-  signMessage,
-} from './util/webCryptoAPI.js';
+  CancelStrategyOrderRequestV3,
+  GetHistoryStrategyOrdersRequestV3,
+  GetUnfilledStrategyOrdersRequestV3,
+  ModifyStrategyOrderRequestV3,
+  PlaceStrategyOrderRequestV3,
+} from './types/request/v3/strategy.js';
 import {
-  getMaxTopicsPerSubscribeEvent,
-  getNormalisedTopicRequests,
-  getWsUrl,
-  isPrivateChannel,
-  WS_AUTH_ON_CONNECT_KEYS,
-  WS_KEY_MAP,
-  WsTopicRequest,
-} from './util/websocket-util.js';
-import { WSConnectedResult } from './util/WsStore.types.js';
-⋮----
-export class WebsocketClientV2 extends BaseWebsocketClient<
-⋮----
-WsRequestOperationBitget<object> // subscribe requests have an "args" parameter with an object within
+  BatchModifyOrderRequestV3,
+  CancelAllOrdersRequestV3,
+  CancelBatchOrdersRequestV3,
+  CancelOrderRequestV3,
+  CloseAllPositionsRequestV3,
+  CountdownCancelAllRequestV3,
+  GetCurrentPositionRequestV3,
+  GetFillsRequestV3,
+  GetHistoryOrdersRequestV3,
+  GetMaxOpenAvailableRequestV3,
+  GetOrderInfoRequestV3,
+  GetPositionHistoryRequestV3,
+  GetUnfilledOrdersRequestV3,
+  ModifyOrderRequestV3,
+  PlaceBatchOrdersRequestV3,
+  PlaceOrderRequestV3,
+} from './types/request/v3/trade.js';
+import { APIResponse } from './types/response/v1/shared.js';
+import {
+  AccountAssetsV3,
+  AccountSettingsV3,
+  ConvertRecordV3,
+  CreateSubAccountApiKeyResponseV3,
+  CreateSubAccountResponseV3,
+  DepositAddressV3,
+  DepositRecordV3,
+  FinancialRecordV3,
+  FundingAssetV3,
+  MaxTransferableV3,
+  OpenInterestLimitV3,
+  PaymentCoinV3,
+  RepayableCoinV3,
+  RepayResponseV3,
+  SubAccountApiKeyV3,
+  SubAccountV3,
+  SubTransferRecordV3,
+  SubUnifiedAssetV3,
+  TaxRecordV3,
+  TransferResponseV3,
+  UpdateSubAccountApiKeyResponseV3,
+  WithdrawRecordV3,
+  WithdrawResponseV3,
+} from './types/response/v3/account.js';
+import {
+  BindUidResponseV3,
+  CoinInfoV3,
+  LoanOrderV3,
+  LoanProductInfoV3,
+  LoanSymbolsV3,
+  LoanTransfersV3,
+  LTVConvertResponseV3,
+  RepaidHistoryItemV3,
+} from './types/response/v3/loan.js';
+import {
+  CandlestickV3,
+  ContractOiV3,
+  CurrentFundingRateV3,
+  DiscountRateV3,
+  HistoryFundingRateV3,
+  InstrumentV3,
+  MarginLoanV3,
+  OpenInterestV3,
+  OrderBookV3,
+  PositionTierV3,
+  ProofOfReservesV3,
+  PublicFillV3,
+  RiskReserveV3,
+  TickerV3,
+} from './types/response/v3/public.js';
+import {
+  ModifyStrategyOrderResponseV3,
+  PlaceStrategyOrderResponseV3,
+  StrategyOrderV3,
+} from './types/response/v3/strategy.js';
+import {
+  BatchModifyOrderResponseV3,
+  CancelAllOrdersResponseV3,
+  CancelBatchOrdersResponseV3,
+  CancelOrderResponseV3,
+  CloseAllPositionsResponseV3,
+  CurrentPositionV3,
+  FillV3,
+  GetMaxOpenAvailableResponseV3,
+  HistoryOrderV3,
+  ModifyOrderResponseV3,
+  OrderInfoV3,
+  PlaceBatchOrdersResponseV3,
+  PlaceOrderResponseV3,
+  PositionAdlRankV3,
+  PositionHistoryV3,
+  UnfilledOrderV3,
+} from './types/response/v3/trade.js';
+import BaseRestClient from './util/BaseRestClient.js';
+import { REST_CLIENT_TYPE_ENUM } from './util/requestUtils.js';
 ⋮----
 /**
-   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
-   */
-public connectAll(): Promise<WSConnectedResult | undefined>[]
+ * REST API client for all V3 endpoints
+ */
+export class RestClientV3 extends BaseRestClient
 ⋮----
-/** Some private channels use `coin` instead of `instId`. This method handles building the sub/unsub request */
-private getSubRequest(
-    instType: BitgetInstTypeV2,
-    topic: WsTopicV2,
-    coin: string = 'default',
-): WsTopicRequest<string>
+getClientType()
 ⋮----
 /**
-   * Subscribe to a topic
-   * @param instType instrument type (refer to API docs).
-   * @param topic topic name (e.g. "ticker").
-   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics.
-   */
-public subscribeTopic(
-    instType: BitgetInstTypeV2,
-    topic: WsTopicV2,
-    coin: string = 'default',
-)
-⋮----
-/**
-   * Unsubscribe from a topic
-   * @param instType instrument type (refer to API docs).
-   * @param topic topic name (e.g. "ticker").
-   * @param instId instrument ID (e.g. "BTCUSDT"). Use "default" for private topics to get all symbols.
-   */
-public unsubscribeTopic(
-    instType: BitgetInstTypeV2,
-    topic: WsTopicV2,
-    coin: string = 'default',
-)
-⋮----
-/**
-   * Request subscription to one or more topics. Pass topics as either an array of strings,
-   * or array of objects (if the topic has parameters).
    *
-   * Objects should be formatted as {topic: string, params: object, category: CategoryV5}.
-   *
-   * - Subscriptions are automatically routed to the correct websocket connection.
-   * - Authentication/connection is automatic.
-   * - Resubscribe after network issues is automatic.
-   *
-   * Call `unsubscribe(topics)` to remove topics
-   */
-public subscribe(
-    requests:
-      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)
-      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)[],
-    wsKey: WsKey,
-): Promise<unknown>
-⋮----
-/**
-   * Unsubscribe from one or more topics. Similar to subscribe() but in reverse.
-   *
-   * - Requests are automatically routed to the correct websocket connection.
-   * - These topics will be removed from the topic cache, so they won't be subscribed to again.
-   */
-public unsubscribe(
-    requests:
-      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)
-      | (WsTopicRequest<WsTopicV2 | string> | WsTopicV2)[],
-    wsKey: WsKey,
-)
-⋮----
-/**
-   *
-   *
-   * Internal methods required to integrate with the BaseWSClient
-   *
+   * Custom SDK functions
    *
    */
 ⋮----
-protected sendPingEvent(wsKey: WsKey): void
-⋮----
-protected sendPongEvent(wsKey: WsKey): void
-⋮----
-protected isWsPing(data: any): boolean
-⋮----
-protected isWsPong(data: any): boolean
-⋮----
-protected isPrivateTopicRequest(
-    _request: WsTopicRequest<string>,
-    wsKey: WsKey,
-): boolean
-⋮----
-protected getPrivateWSKeys(): WsKey[]
-⋮----
-protected isAuthOnConnectWsKey(wsKey: WsKey): boolean
-⋮----
-protected async getWsUrl(wsKey: WsKey): Promise<string>
-⋮----
-protected getMaxTopicsPerSubscribeEvent(wsKey: WsKey): number | null
-⋮----
 /**
-   * @returns one or more correctly structured request events for performing a operations over WS. This can vary per exchange spec.
+   * This method is used to get the latency and time sync between the client and the server.
+   * This is not official API endpoint and is only used for internal testing purposes.
+   * Use this method to check the latency and time sync between the client and the server.
+   * Final values might vary slightly, but it should be within few ms difference.
+   * If you have any suggestions or improvements to this measurement, please create an issue or pull request on GitHub.
    */
-protected async getWsRequestEvents(
-    operation: WSOperation,
-    requests: WsTopicRequest<string, object>[],
-): Promise<MidflightWsRequestEvent<WsRequestOperationBitget<object>>[]>
+async fetchLatencySummary(): Promise<any>
 ⋮----
-// Previously used to track topics in a request. Keeping this for subscribe/unsubscribe requests, no need for incremental values
+// Adjust server time by adding estimated one-way latency
 ⋮----
-/**
-      {
-        "op":"subscribe",
-        "args":[
-            {
-                "instType":"SPOT",
-                "channel":"ticker",
-                "instId":"BTCUSDT"
-            },
-            {
-                "instType":"SPOT",
-                "channel":"candle5m",
-                "instId":"BTCUSDT"
-            }
-        ]
-      }
-    */
+// Calculate time difference between adjusted server time and local time
 ⋮----
-// const request = {
-//   topic: 'ticker',
-//   payload: { instType: 'SPOT', instId: 'BTCUSDT' },
-// };
-// becomes:
-// const request = {
-//   channel: 'ticker',
-//   instType: 'SPOT',
-//   instId: 'BTCUSDT',
-// };
-⋮----
-private async getWsAuthSignature(
-    wsKey: WsKey,
-): Promise<
-⋮----
-private async signMessage(
-    paramsStr: string,
-    secret: string,
-    method: SignEncodeMethod,
-    algorithm: SignAlgorithm,
-): Promise<string>
-⋮----
-protected async getWsAuthRequestEvent(
-    wsKey: WsKey,
-): Promise<WsRequestOperationBitget<WSOperationLoginParams>>
+async fetchServerTime(): Promise<number>
 ⋮----
 /**
-   * Abstraction called to sort ws events into emittable event types (response to a request, data update, etc)
+   *
+   * Public endpoints
+   *
    */
-protected resolveEmittableEvents(
-    wsKey: WsKey,
-    event: MessageEventLike,
-): EmittableEvent[]
 ⋮----
-// v2 event processing
-⋮----
-// v2 authentication event
-⋮----
-// messageType: typeof msg,
-// messageString: JSON.stringify(msg),
-⋮----
-// messageType: typeof msg,
-// messageString: JSON.stringify(msg),
-⋮----
-// fallback emit anyway
+getServerTime(): Promise<
+    APIResponse<{
+      serverTime: string;
+    }>
+  > {
+    return this.get('/api/v3/public/time');
 ⋮----
 /**
-   * @deprecrated not supported by Bitget's V2 API offering
+   *
+   * =====Market======= endpoints
+   *
    */
-async sendWSAPIRequest(): Promise<unknown>
+⋮----
+/**
+   * Get Instruments
+   */
+getInstruments(
+    params: GetInstrumentsRequestV3,
+): Promise<APIResponse<InstrumentV3[]>>
+⋮----
+/**
+   * Get Tickers
+   */
+getTickers(params: GetTickersRequestV3): Promise<APIResponse<TickerV3[]>>
+⋮----
+/**
+   * Get OrderBook
+   */
+getOrderBook(
+    params: GetOrderBookRequestV3,
+): Promise<APIResponse<OrderBookV3>>
+⋮----
+/**
+   * Get Recent Public Fills
+   */
+getFills(
+    params: GetPublicFillsRequestV3,
+): Promise<APIResponse<PublicFillV3[]>>
+⋮----
+/**
+   * Get Proof Of Reserves
+   */
+getProofOfReserves(): Promise<APIResponse<ProofOfReservesV3>>
+⋮----
+/**
+   * Get Open Interest
+   */
+getOpenInterest(
+    params: GetOpenInterestRequestV3,
+): Promise<APIResponse<OpenInterestV3>>
+⋮----
+/**
+   * Get Kline/Candlestick
+   * Maximum number of returned entries: 1,000
+   */
+getCandles(
+    params: GetCandlesRequestV3,
+): Promise<APIResponse<CandlestickV3[]>>
+⋮----
+/**
+   * Get Kline/Candlestick History
+   */
+getHistoryCandles(
+    params: GetHistoryCandlesRequestV3,
+): Promise<APIResponse<CandlestickV3[]>>
+⋮----
+/**
+   * Get Current Funding Rate
+   */
+getCurrentFundingRate(
+    params: GetCurrentFundingRateRequestV3,
+): Promise<APIResponse<CurrentFundingRateV3[]>>
+⋮----
+/**
+   * Get Funding Rate History
+   */
+getHistoryFundingRate(
+    params: GetHistoryFundingRateRequestV3,
+): Promise<APIResponse<HistoryFundingRateV3[]>>
+⋮----
+/**
+   * Get Risk Reserve
+   */
+getRiskReserve(
+    params: GetRiskReserveRequestV3,
+): Promise<APIResponse<RiskReserveV3>>
+⋮----
+/**
+   * Get Discount Rate
+   */
+getDiscountRate(): Promise<APIResponse<DiscountRateV3[]>>
+⋮----
+/**
+   * Get Margin Loan
+   */
+getMarginLoans(
+    params: GetMarginLoansRequestV3,
+): Promise<APIResponse<MarginLoanV3>>
+⋮----
+/**
+   * Get Position Tier
+   */
+getPositionTier(
+    params: GetPositionTierRequestV3,
+): Promise<APIResponse<PositionTierV3[]>>
+⋮----
+/**
+   * Get Open Interest Limit
+   */
+getContractsOi(
+    params: GetContractsOiRequestV3,
+): Promise<APIResponse<ContractOiV3[]>>
+⋮----
+/**
+   *
+   * =====Account======= endpoints
+   *
+   */
+⋮----
+/**
+   * Get Account Assets
+   */
+getBalances(): Promise<APIResponse<AccountAssetsV3>>
+⋮----
+/**
+   * Get Fund Account Assets
+   */
+getFundingAssets(
+    params?: GetFundingAssetsRequestV3,
+): Promise<APIResponse<FundingAssetV3[]>>
+⋮----
+/**
+   * Get Account Info
+   */
+getAccountSettings(): Promise<APIResponse<AccountSettingsV3>>
+⋮----
+/**
+   * Set Leverage
+   */
+setLeverage(params: SetLeverageRequestV3): Promise<APIResponse<string>>
+⋮----
+/**
+   * Set Holding Mode
+   */
+setHoldMode(params: {
+    holdMode: 'one_way_mode' | 'hedge_mode';
+}): Promise<APIResponse<string>>
+⋮----
+/**
+   * Get Financial Records
+   */
+getFinancialRecords(params: GetFinancialRecordsRequestV3): Promise<
+    APIResponse<{
+      list: FinancialRecordV3[];
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/financial-records', params);
+⋮----
+/**
+   * Get Repayable Coins
+   */
+getRepayableCoins(): Promise<
+    APIResponse<{
+      repayableCoinList: RepayableCoinV3[];
+      maxSelection: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/repayable-coins');
+⋮----
+/**
+   * Get Payment Coins
+   */
+getPaymentCoins(): Promise<
+    APIResponse<{
+      paymentCoinList: PaymentCoinV3[];
+      maxSelection: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/payment-coins');
+⋮----
+/**
+   * Repay
+   */
+submitRepay(params: RepayRequestV3): Promise<APIResponse<RepayResponseV3>>
+⋮----
+/**
+   * Get Convert Records
+   */
+getConvertRecords(params: GetConvertRecordsRequestV3): Promise<
+    APIResponse<{
+      list: ConvertRecordV3[];
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/convert-records', params);
+⋮----
+/**
+   * Set up deposit account - Configure default recharge account for a certain symbol
+   * This configuration item remains valid for a long time. That is, once a user sets a default
+   * recharge account for a certain symbol, it will be retained permanently, and there is no need to reconfigure it.
+   * Permission: UTA mgt. (read & write)
+   */
+setDepositAccount(
+    params: SetDepositAccountRequestV3,
+): Promise<APIResponse<string>>
+⋮----
+/**
+   * Switch Deduct - Set BGB deduction
+   */
+switchDeduct(params: SwitchDeductRequestV3): Promise<APIResponse<string>>
+⋮----
+/**
+   * Get Deduct Info - Get BGB deduction status
+   */
+getDeductInfo(): Promise<
+    APIResponse<{
+      deduct: 'on' | 'off';
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/deduct-info');
+⋮----
+/**
+   * Get Trading Fee Rate
+   */
+getFeeRate(params: GetFeeRateRequestV3): Promise<
+    APIResponse<{
+      makerFeeRate: string;
+      takerFeeRate: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/fee-rate', params);
+⋮----
+/**
+   * Get Max Transferable
+   *
+   * - Rate limit: 3 req/sec/UID
+   * - Permission: UTA mgt. (read)
+   * - Get the maximum transferable amount for the unified account.
+   */
+getMaxTransferable(
+    params: GetMaxTransferableRequestV3,
+): Promise<APIResponse<MaxTransferableV3>>
+⋮----
+/**
+   * Get Open Interest Limit
+   *
+   * - Rate limit: 5/sec/UID
+   * - Get open interest limit for a symbol
+   */
+getOpenInterestLimit(
+    params: GetOpenInterestLimitRequestV3,
+): Promise<APIResponse<OpenInterestLimitV3>>
+⋮----
+/**
+   * Switch Account - Switch to classic account mode
+   * Only supports parent accounts.
+   * This endpoint is only used for switching to classic account mode.
+   * Please note that since the account switching process takes approximately 1 minute,
+   * the successful response you receive only indicates that the request has been received,
+   * and does not mean that the account has been successfully switched to the classic account.
+   * Please use the query switching status interface to confirm whether the account switching is successful.
+   */
+downgradeAccountToClassic(): Promise<APIResponse<null>>
+⋮----
+/**
+   * Get Switch Status - Get account switching status
+   * Only supports parent accounts.
+   */
+getUnifiedAccountSwitchStatus(): Promise<
+    APIResponse<{
+      status: 'processProcessing' | 'successSuccess' | 'failFailed';
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/switch-status');
+⋮----
+/**
+   * Get Tax Records
+   *
+   * - Rate limit: 1/sec/UID
+   * - Data query range: 366 days
+   * - Please use the tax API Key to request Creation Portal
+   * - Get Unified Account Tax Records
+   */
+getTaxRecords(
+    params: GetTaxRecordsRequestV3,
+): Promise<APIResponse<TaxRecordV3[]>>
+⋮----
+/**
+   *
+   * =====SubAccount======= endpoints
+   *
+   */
+⋮----
+/**
+   * Create Sub-account
+   */
+createSubAccount(
+    params: CreateSubAccountRequestV3,
+): Promise<APIResponse<CreateSubAccountResponseV3>>
+⋮----
+/**
+   * Freeze/Unfreeze Sub-account
+   */
+freezeSubAccount(
+    params: FreezeSubAccountRequestV3,
+): Promise<APIResponse<object>>
+⋮----
+/**
+   * Get Sub-account Unified Account Assets
+   */
+getSubUnifiedAssets(
+    params?: GetSubUnifiedAssetsRequestV3,
+): Promise<APIResponse<SubUnifiedAssetV3[]>>
+⋮----
+/**
+   * Get Sub-account List
+   */
+getSubAccountList(params?: GetSubAccountListRequestV3): Promise<
+    APIResponse<{
+      list: SubAccountV3[];
+      hasNext: boolean;
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/user/sub-list', params);
+⋮----
+/**
+   * Create Sub-account API Key
+   */
+createSubAccountApiKey(
+    params: CreateSubAccountApiKeyRequestV3,
+): Promise<APIResponse<CreateSubAccountApiKeyResponseV3>>
+⋮----
+/**
+   * Modify Sub-account API Key
+   */
+updateSubAccountApiKey(
+    params: UpdateSubAccountApiKeyRequestV3,
+): Promise<APIResponse<UpdateSubAccountApiKeyResponseV3>>
+⋮----
+/**
+   * Delete Sub-account API Key
+   */
+deleteSubAccountApiKey(
+    params: DeleteSubAccountApiKeyRequestV3,
+): Promise<APIResponse<any>>
+⋮----
+/**
+   * Get Sub-account API Keys
+   */
+getSubAccountApiKeys(params: GetSubAccountApiKeysRequestV3): Promise<
+    APIResponse<{
+      items: SubAccountApiKeyV3[];
+      hasNext: boolean;
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/user/sub-api-list', params);
+⋮----
+/**
+   *
+   * =====Transfer======= endpoints
+   *
+   */
+⋮----
+/**
+   * Get Transferable Coins
+   */
+getTransferableCoins(
+    params: GetTransferableCoinsRequestV3,
+): Promise<APIResponse<string[]>>
+⋮----
+/**
+   * Transfer
+   */
+submitTransfer(
+    params: TransferRequestV3,
+): Promise<APIResponse<TransferResponseV3>>
+⋮----
+/**
+   * Main-Sub Account Transfer
+   */
+subAccountTransfer(params: SubAccountTransferRequestV3): Promise<
+    APIResponse<{
+      transferId: string;
+      clientOid: string;
+    }>
+  > {
+    return this.postPrivate('/api/v3/account/sub-transfer', params);
+⋮----
+/**
+   * Get Main-Sub Transfer Records
+   */
+getSubTransferRecords(params?: GetSubTransferRecordsRequestV3): Promise<
+    APIResponse<{
+      items: SubTransferRecordV3[];
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/account/sub-transfer-record', params);
+⋮----
+/**
+   *
+   * =====Deposit======= endpoints
+   *
+   */
+⋮----
+/**
+   * Get Deposit Address
+   */
+getDepositAddress(
+    params: GetDepositAddressRequestV3,
+): Promise<APIResponse<DepositAddressV3>>
+⋮----
+/**
+   * Get Sub Deposit Address
+   */
+getSubDepositAddress(
+    params: GetSubDepositAddressRequestV3,
+): Promise<APIResponse<DepositAddressV3>>
+⋮----
+/**
+   * Get Deposit Records
+   */
+getDepositRecords(
+    params: GetDepositRecordsRequestV3,
+): Promise<APIResponse<DepositRecordV3[]>>
+⋮----
+/**
+   * Get Sub Deposit Records
+   */
+getSubDepositRecords(
+    params: GetSubDepositRecordsRequestV3,
+): Promise<APIResponse<DepositRecordV3[]>>
+⋮----
+/**
+   *
+   * =====Withdraw======= endpoints
+   *
+   */
+⋮----
+/**
+   * Withdraw - Includes on-chain withdrawals and internal transfers
+   */
+submitWithdraw(
+    params: WithdrawRequestV3,
+): Promise<APIResponse<WithdrawResponseV3>>
+⋮----
+/**
+   * Get Withdraw Records
+   */
+getWithdrawRecords(
+    params: GetWithdrawRecordsRequestV3,
+): Promise<APIResponse<WithdrawRecordV3[]>>
+⋮----
+/**
+   *
+   * =====Trade======= endpoints
+   *
+   */
+⋮----
+/**
+   * Place Order
+   */
+submitNewOrder(
+    params: PlaceOrderRequestV3,
+): Promise<APIResponse<PlaceOrderResponseV3>>
+⋮----
+/**
+   * Modify Order
+   */
+modifyOrder(
+    params: ModifyOrderRequestV3,
+): Promise<APIResponse<ModifyOrderResponseV3>>
+⋮----
+/**
+   * Cancel Order
+   */
+cancelOrder(
+    params: CancelOrderRequestV3,
+): Promise<APIResponse<CancelOrderResponseV3>>
+⋮----
+/**
+   * Batch Order
+   */
+placeBatchOrders(
+    params: PlaceBatchOrdersRequestV3[],
+): Promise<APIResponse<PlaceBatchOrdersResponseV3[]>>
+⋮----
+/**
+   * Batch Modify Orders
+   */
+batchModifyOrders(
+    params: BatchModifyOrderRequestV3[],
+): Promise<APIResponse<BatchModifyOrderResponseV3[]>>
+⋮----
+/**
+   * Batch Cancel
+   */
+cancelBatchOrders(
+    params: CancelBatchOrdersRequestV3[],
+): Promise<APIResponse<CancelBatchOrdersResponseV3[]>>
+⋮----
+/**
+   * Cancel All Orders
+   */
+cancelAllOrders(
+    params: CancelAllOrdersRequestV3,
+): Promise<APIResponse<CancelAllOrdersResponseV3>>
+⋮----
+/**
+   * Close All Positions
+   */
+closeAllPositions(
+    params: CloseAllPositionsRequestV3,
+): Promise<APIResponse<CloseAllPositionsResponseV3>>
+⋮----
+/**
+   * Get Order Details
+   */
+getOrderInfo(
+    params: GetOrderInfoRequestV3,
+): Promise<APIResponse<OrderInfoV3>>
+⋮----
+/**
+   * Get Open Orders
+   */
+getUnfilledOrders(params?: GetUnfilledOrdersRequestV3): Promise<
+    APIResponse<{
+      list: UnfilledOrderV3[];
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/trade/unfilled-orders', params);
+⋮----
+/**
+   * Get Order History
+   */
+getHistoryOrders(params: GetHistoryOrdersRequestV3): Promise<
+    APIResponse<{
+      list: HistoryOrderV3[];
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/trade/history-orders', params);
+⋮----
+/**
+   * Get Fill History
+   */
+getTradeFills(params?: GetFillsRequestV3): Promise<
+    APIResponse<{
+      list: FillV3[];
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/trade/fills', params);
+⋮----
+/**
+   * Get Position Info
+   */
+getCurrentPosition(params: GetCurrentPositionRequestV3): Promise<
+    APIResponse<{
+      list: CurrentPositionV3[];
+    }>
+  > {
+    return this.getPrivate('/api/v3/position/current-position', params);
+⋮----
+/**
+   * Get Positions History
+   */
+getPositionHistory(params: GetPositionHistoryRequestV3): Promise<
+    APIResponse<{
+      list: PositionHistoryV3[];
+      cursor: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/position/history-position', params);
+⋮----
+/**
+   * Get Max Open Available
+   */
+getMaxOpenAvailable(
+    params: GetMaxOpenAvailableRequestV3,
+): Promise<APIResponse<GetMaxOpenAvailableResponseV3>>
+⋮----
+/**
+   * Get Position ADL Rank - Get position auto-deleveraging ranking
+   */
+getPositionAdlRank(): Promise<APIResponse<PositionAdlRankV3[]>>
+⋮----
+/**
+   * CountDown Cancel All
+   */
+countdownCancelAll(
+    params: CountdownCancelAllRequestV3,
+): Promise<APIResponse<string>>
+⋮----
+/**
+   *
+   * =====Inst Loan======= endpoints
+   *
+   */
+⋮----
+/**
+   * Get Transferred Quantity
+   */
+getLoanTransfered(
+    params: GetTransferedRequestV3,
+): Promise<APIResponse<LoanTransfersV3>>
+⋮----
+/**
+   * Get Trade Symbols
+   */
+getLoanSymbols(
+    params: GetSymbolsRequestV3,
+): Promise<APIResponse<LoanSymbolsV3>>
+⋮----
+/**
+   * Get Risk Unit
+   */
+getLoanRiskUnit(): Promise<
+    APIResponse<{
+      riskUnitId: string[];
+    }>
+  > {
+    return this.getPrivate('/api/v3/ins-loan/risk-unit');
+⋮----
+/**
+   * Get Repayment Orders
+   */
+getLoanRepaidHistory(
+    params?: GetRepaidHistoryRequestV3,
+): Promise<APIResponse<RepaidHistoryItemV3[]>>
+⋮----
+/**
+   * Get Product Info
+   */
+getLoanProductInfo(
+    params: GetProductInfosRequestV3,
+): Promise<APIResponse<LoanProductInfoV3>>
+⋮----
+/**
+   * Get Loan Orders
+   */
+getLoanOrder(
+    params?: GetLoanOrderRequestV3,
+): Promise<APIResponse<LoanOrderV3[]>>
+⋮----
+/**
+   * Get LTV
+   */
+getLoanLTVConvert(
+    params?: GetLTVConvertRequestV3,
+): Promise<APIResponse<LTVConvertResponseV3>>
+⋮----
+/**
+   * Get Margin Coin Info
+   */
+getLoanMarginCoinInfo(params: GetEnsureCoinsRequestV3): Promise<
+    APIResponse<{
+      productId: string;
+      coinInfo: CoinInfoV3[];
+    }>
+  > {
+    return this.getPrivate('/api/v3/ins-loan/ensure-coins-convert', params);
+⋮----
+/**
+   * Bind/Unbind UID to Risk Unit
+   */
+bindLoanUid(
+    params: BindUidRequestV3,
+): Promise<APIResponse<BindUidResponseV3>>
+⋮----
+/**
+   *
+   * =====Strategy======= endpoints
+   *
+   */
+⋮----
+/**
+   * Place Strategy Order
+   */
+submitStrategyOrder(
+    params: PlaceStrategyOrderRequestV3,
+): Promise<APIResponse<PlaceStrategyOrderResponseV3>>
+⋮----
+/**
+   * Modify Strategy Order
+   */
+modifyStrategyOrder(
+    params: ModifyStrategyOrderRequestV3,
+): Promise<APIResponse<ModifyStrategyOrderResponseV3>>
+⋮----
+/**
+   * Cancel Strategy Order
+   */
+cancelStrategyOrder(
+    params: CancelStrategyOrderRequestV3,
+): Promise<APIResponse<null>>
+⋮----
+/**
+   * Get Unfilled Strategy Orders
+   */
+getUnfilledStrategyOrders(
+    params: GetUnfilledStrategyOrdersRequestV3,
+): Promise<APIResponse<StrategyOrderV3[]>>
+⋮----
+/**
+   * Get Strategy Order History
+   */
+getHistoryStrategyOrders(params: GetHistoryStrategyOrdersRequestV3): Promise<
+    APIResponse<{
+      list: StrategyOrderV3[];
+      cursor?: string;
+    }>
+  > {
+    return this.getPrivate('/api/v3/trade/history-strategy-orders', params);
 
 ================
 File: README.md
@@ -13693,886 +15072,11 @@ Contributions are encouraged, I will review any incoming pull requests. See the 
 <!-- template_star_history_end -->
 
 ================
-File: src/rest-client-v3.ts
-================
-import {
-  CreateSubAccountApiKeyRequestV3,
-  CreateSubAccountRequestV3,
-  DeleteSubAccountApiKeyRequestV3,
-  FreezeSubAccountRequestV3,
-  GetConvertRecordsRequestV3,
-  GetDepositAddressRequestV3,
-  GetDepositRecordsRequestV3,
-  GetFeeRateRequestV3,
-  GetFinancialRecordsRequestV3,
-  GetFundingAssetsRequestV3,
-  GetSubAccountApiKeysRequestV3,
-  GetSubAccountListRequestV3,
-  GetSubDepositAddressRequestV3,
-  GetSubDepositRecordsRequestV3,
-  GetSubTransferRecordsRequestV3,
-  GetSubUnifiedAssetsRequestV3,
-  GetTransferableCoinsRequestV3,
-  GetWithdrawRecordsRequestV3,
-  RepayRequestV3,
-  SetDepositAccountRequestV3,
-  SetLeverageRequestV3,
-  SubAccountTransferRequestV3,
-  SwitchDeductRequestV3,
-  TransferRequestV3,
-  UpdateSubAccountApiKeyRequestV3,
-  WithdrawRequestV3,
-} from './types/request/v3/account.js';
-import {
-  BindUidRequestV3,
-  GetEnsureCoinsRequestV3,
-  GetLoanOrderRequestV3,
-  GetLTVConvertRequestV3,
-  GetProductInfosRequestV3,
-  GetRepaidHistoryRequestV3,
-  GetSymbolsRequestV3,
-  GetTransferedRequestV3,
-} from './types/request/v3/loan.js';
-import {
-  GetCandlesRequestV3,
-  GetContractsOiRequestV3,
-  GetCurrentFundingRateRequestV3,
-  GetHistoryCandlesRequestV3,
-  GetHistoryFundingRateRequestV3,
-  GetInstrumentsRequestV3,
-  GetMarginLoansRequestV3,
-  GetOpenInterestRequestV3,
-  GetOrderBookRequestV3,
-  GetPositionTierRequestV3,
-  GetPublicFillsRequestV3,
-  GetRiskReserveRequestV3,
-  GetTickersRequestV3,
-} from './types/request/v3/public.js';
-import {
-  CancelStrategyOrderRequestV3,
-  GetHistoryStrategyOrdersRequestV3,
-  GetUnfilledStrategyOrdersRequestV3,
-  ModifyStrategyOrderRequestV3,
-  PlaceStrategyOrderRequestV3,
-} from './types/request/v3/strategy.js';
-import {
-  BatchModifyOrderRequestV3,
-  CancelAllOrdersRequestV3,
-  CancelBatchOrdersRequestV3,
-  CancelOrderRequestV3,
-  CloseAllPositionsRequestV3,
-  CountdownCancelAllRequestV3,
-  GetCurrentPositionRequestV3,
-  GetFillsRequestV3,
-  GetHistoryOrdersRequestV3,
-  GetMaxOpenAvailableRequestV3,
-  GetOrderInfoRequestV3,
-  GetPositionHistoryRequestV3,
-  GetUnfilledOrdersRequestV3,
-  ModifyOrderRequestV3,
-  PlaceBatchOrdersRequestV3,
-  PlaceOrderRequestV3,
-} from './types/request/v3/trade.js';
-import { APIResponse } from './types/response/v1/shared.js';
-import {
-  AccountAssetsV3,
-  AccountSettingsV3,
-  ConvertRecordV3,
-  CreateSubAccountApiKeyResponseV3,
-  CreateSubAccountResponseV3,
-  DepositAddressV3,
-  DepositRecordV3,
-  FinancialRecordV3,
-  FundingAssetV3,
-  PaymentCoinV3,
-  RepayableCoinV3,
-  RepayResponseV3,
-  SubAccountApiKeyV3,
-  SubAccountV3,
-  SubTransferRecordV3,
-  SubUnifiedAssetV3,
-  TransferResponseV3,
-  UpdateSubAccountApiKeyResponseV3,
-  WithdrawRecordV3,
-  WithdrawResponseV3,
-} from './types/response/v3/account.js';
-import {
-  BindUidResponseV3,
-  CoinInfoV3,
-  LoanOrderV3,
-  LoanProductInfoV3,
-  LoanSymbolsV3,
-  LoanTransfersV3,
-  LTVConvertResponseV3,
-  RepaidHistoryItemV3,
-} from './types/response/v3/loan.js';
-import {
-  CandlestickV3,
-  ContractOiV3,
-  CurrentFundingRateV3,
-  DiscountRateV3,
-  HistoryFundingRateV3,
-  InstrumentV3,
-  MarginLoanV3,
-  OpenInterestV3,
-  OrderBookV3,
-  PositionTierV3,
-  ProofOfReservesV3,
-  PublicFillV3,
-  RiskReserveV3,
-  TickerV3,
-} from './types/response/v3/public.js';
-import {
-  ModifyStrategyOrderResponseV3,
-  PlaceStrategyOrderResponseV3,
-  StrategyOrderV3,
-} from './types/response/v3/strategy.js';
-import {
-  BatchModifyOrderResponseV3,
-  CancelAllOrdersResponseV3,
-  CancelBatchOrdersResponseV3,
-  CancelOrderResponseV3,
-  CloseAllPositionsResponseV3,
-  CurrentPositionV3,
-  FillV3,
-  GetMaxOpenAvailableResponseV3,
-  HistoryOrderV3,
-  ModifyOrderResponseV3,
-  OrderInfoV3,
-  PlaceBatchOrdersResponseV3,
-  PlaceOrderResponseV3,
-  PositionAdlRankV3,
-  PositionHistoryV3,
-  UnfilledOrderV3,
-} from './types/response/v3/trade.js';
-import BaseRestClient from './util/BaseRestClient.js';
-import { REST_CLIENT_TYPE_ENUM } from './util/requestUtils.js';
-⋮----
-/**
- * REST API client for all V3 endpoints
- */
-export class RestClientV3 extends BaseRestClient
-⋮----
-getClientType()
-⋮----
-/**
-   *
-   * Custom SDK functions
-   *
-   */
-⋮----
-/**
-   * This method is used to get the latency and time sync between the client and the server.
-   * This is not official API endpoint and is only used for internal testing purposes.
-   * Use this method to check the latency and time sync between the client and the server.
-   * Final values might vary slightly, but it should be within few ms difference.
-   * If you have any suggestions or improvements to this measurement, please create an issue or pull request on GitHub.
-   */
-async fetchLatencySummary(): Promise<any>
-⋮----
-// Adjust server time by adding estimated one-way latency
-⋮----
-// Calculate time difference between adjusted server time and local time
-⋮----
-async fetchServerTime(): Promise<number>
-⋮----
-/**
-   *
-   * Public endpoints
-   *
-   */
-⋮----
-getServerTime(): Promise<
-    APIResponse<{
-      serverTime: string;
-    }>
-  > {
-    return this.get('/api/v3/public/time');
-⋮----
-/**
-   *
-   * =====Market======= endpoints
-   *
-   */
-⋮----
-/**
-   * Get Instruments
-   */
-getInstruments(
-    params: GetInstrumentsRequestV3,
-): Promise<APIResponse<InstrumentV3[]>>
-⋮----
-/**
-   * Get Tickers
-   */
-getTickers(params: GetTickersRequestV3): Promise<APIResponse<TickerV3[]>>
-⋮----
-/**
-   * Get OrderBook
-   */
-getOrderBook(
-    params: GetOrderBookRequestV3,
-): Promise<APIResponse<OrderBookV3>>
-⋮----
-/**
-   * Get Recent Public Fills
-   */
-getFills(
-    params: GetPublicFillsRequestV3,
-): Promise<APIResponse<PublicFillV3[]>>
-⋮----
-/**
-   * Get Proof Of Reserves
-   */
-getProofOfReserves(): Promise<APIResponse<ProofOfReservesV3>>
-⋮----
-/**
-   * Get Open Interest
-   */
-getOpenInterest(
-    params: GetOpenInterestRequestV3,
-): Promise<APIResponse<OpenInterestV3>>
-⋮----
-/**
-   * Get Kline/Candlestick
-   */
-getCandles(
-    params: GetCandlesRequestV3,
-): Promise<APIResponse<CandlestickV3[]>>
-⋮----
-/**
-   * Get Kline/Candlestick History
-   */
-getHistoryCandles(
-    params: GetHistoryCandlesRequestV3,
-): Promise<APIResponse<CandlestickV3[]>>
-⋮----
-/**
-   * Get Current Funding Rate
-   */
-getCurrentFundingRate(
-    params: GetCurrentFundingRateRequestV3,
-): Promise<APIResponse<CurrentFundingRateV3[]>>
-⋮----
-/**
-   * Get Funding Rate History
-   */
-getHistoryFundingRate(
-    params: GetHistoryFundingRateRequestV3,
-): Promise<APIResponse<HistoryFundingRateV3[]>>
-⋮----
-/**
-   * Get Risk Reserve
-   */
-getRiskReserve(
-    params: GetRiskReserveRequestV3,
-): Promise<APIResponse<RiskReserveV3>>
-⋮----
-/**
-   * Get Discount Rate
-   */
-getDiscountRate(): Promise<APIResponse<DiscountRateV3[]>>
-⋮----
-/**
-   * Get Margin Loan
-   */
-getMarginLoans(
-    params: GetMarginLoansRequestV3,
-): Promise<APIResponse<MarginLoanV3>>
-⋮----
-/**
-   * Get Position Tier
-   */
-getPositionTier(
-    params: GetPositionTierRequestV3,
-): Promise<APIResponse<PositionTierV3[]>>
-⋮----
-/**
-   * Get Open Interest Limit
-   */
-getContractsOi(
-    params: GetContractsOiRequestV3,
-): Promise<APIResponse<ContractOiV3[]>>
-⋮----
-/**
-   *
-   * =====Account======= endpoints
-   *
-   */
-⋮----
-/**
-   * Get Account Assets
-   */
-getBalances(): Promise<APIResponse<AccountAssetsV3>>
-⋮----
-/**
-   * Get Fund Account Assets
-   */
-getFundingAssets(
-    params?: GetFundingAssetsRequestV3,
-): Promise<APIResponse<FundingAssetV3[]>>
-⋮----
-/**
-   * Get Account Info
-   */
-getAccountSettings(): Promise<APIResponse<AccountSettingsV3>>
-⋮----
-/**
-   * Set Leverage
-   */
-setLeverage(params: SetLeverageRequestV3): Promise<APIResponse<string>>
-⋮----
-/**
-   * Set Holding Mode
-   */
-setHoldMode(params: {
-    holdMode: 'one_way_mode' | 'hedge_mode';
-}): Promise<APIResponse<string>>
-⋮----
-/**
-   * Get Financial Records
-   */
-getFinancialRecords(params: GetFinancialRecordsRequestV3): Promise<
-    APIResponse<{
-      list: FinancialRecordV3[];
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/financial-records', params);
-⋮----
-/**
-   * Get Repayable Coins
-   */
-getRepayableCoins(): Promise<
-    APIResponse<{
-      repayableCoinList: RepayableCoinV3[];
-      maxSelection: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/repayable-coins');
-⋮----
-/**
-   * Get Payment Coins
-   */
-getPaymentCoins(): Promise<
-    APIResponse<{
-      paymentCoinList: PaymentCoinV3[];
-      maxSelection: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/payment-coins');
-⋮----
-/**
-   * Repay
-   */
-submitRepay(params: RepayRequestV3): Promise<APIResponse<RepayResponseV3>>
-⋮----
-/**
-   * Get Convert Records
-   */
-getConvertRecords(params: GetConvertRecordsRequestV3): Promise<
-    APIResponse<{
-      list: ConvertRecordV3[];
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/convert-records', params);
-⋮----
-/**
-   * Set up deposit account - Configure default recharge account for a certain symbol
-   * This configuration item remains valid for a long time. That is, once a user sets a default
-   * recharge account for a certain symbol, it will be retained permanently, and there is no need to reconfigure it.
-   * Permission: UTA mgt. (read & write)
-   */
-setDepositAccount(
-    params: SetDepositAccountRequestV3,
-): Promise<APIResponse<string>>
-⋮----
-/**
-   * Switch Deduct - Set BGB deduction
-   */
-switchDeduct(params: SwitchDeductRequestV3): Promise<APIResponse<string>>
-⋮----
-/**
-   * Get Deduct Info - Get BGB deduction status
-   */
-getDeductInfo(): Promise<
-    APIResponse<{
-      deduct: 'on' | 'off';
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/deduct-info');
-⋮----
-/**
-   * Get Trading Fee Rate
-   */
-getFeeRate(params: GetFeeRateRequestV3): Promise<
-    APIResponse<{
-      makerFeeRate: string;
-      takerFeeRate: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/fee-rate', params);
-⋮----
-/**
-   * Switch Account - Switch to classic account mode
-   * Only supports parent accounts.
-   * This endpoint is only used for switching to classic account mode.
-   * Please note that since the account switching process takes approximately 1 minute,
-   * the successful response you receive only indicates that the request has been received,
-   * and does not mean that the account has been successfully switched to the classic account.
-   * Please use the query switching status interface to confirm whether the account switching is successful.
-   */
-downgradeAccountToClassic(): Promise<APIResponse<null>>
-⋮----
-/**
-   * Get Switch Status - Get account switching status
-   * Only supports parent accounts.
-   */
-getUnifiedAccountSwitchStatus(): Promise<
-    APIResponse<{
-      status: 'processProcessing' | 'successSuccess' | 'failFailed';
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/switch-status');
-⋮----
-/**
-   *
-   * =====SubAccount======= endpoints
-   *
-   */
-⋮----
-/**
-   * Create Sub-account
-   */
-createSubAccount(
-    params: CreateSubAccountRequestV3,
-): Promise<APIResponse<CreateSubAccountResponseV3>>
-⋮----
-/**
-   * Freeze/Unfreeze Sub-account
-   */
-freezeSubAccount(
-    params: FreezeSubAccountRequestV3,
-): Promise<APIResponse<object>>
-⋮----
-/**
-   * Get Sub-account Unified Account Assets
-   */
-getSubUnifiedAssets(
-    params?: GetSubUnifiedAssetsRequestV3,
-): Promise<APIResponse<SubUnifiedAssetV3[]>>
-⋮----
-/**
-   * Get Sub-account List
-   */
-getSubAccountList(params?: GetSubAccountListRequestV3): Promise<
-    APIResponse<{
-      list: SubAccountV3[];
-      hasNext: boolean;
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/user/sub-list', params);
-⋮----
-/**
-   * Create Sub-account API Key
-   */
-createSubAccountApiKey(
-    params: CreateSubAccountApiKeyRequestV3,
-): Promise<APIResponse<CreateSubAccountApiKeyResponseV3>>
-⋮----
-/**
-   * Modify Sub-account API Key
-   */
-updateSubAccountApiKey(
-    params: UpdateSubAccountApiKeyRequestV3,
-): Promise<APIResponse<UpdateSubAccountApiKeyResponseV3>>
-⋮----
-/**
-   * Delete Sub-account API Key
-   */
-deleteSubAccountApiKey(
-    params: DeleteSubAccountApiKeyRequestV3,
-): Promise<APIResponse<any>>
-⋮----
-/**
-   * Get Sub-account API Keys
-   */
-getSubAccountApiKeys(params: GetSubAccountApiKeysRequestV3): Promise<
-    APIResponse<{
-      items: SubAccountApiKeyV3[];
-      hasNext: boolean;
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/user/sub-api-list', params);
-⋮----
-/**
-   *
-   * =====Transfer======= endpoints
-   *
-   */
-⋮----
-/**
-   * Get Transferable Coins
-   */
-getTransferableCoins(
-    params: GetTransferableCoinsRequestV3,
-): Promise<APIResponse<string[]>>
-⋮----
-/**
-   * Transfer
-   */
-submitTransfer(
-    params: TransferRequestV3,
-): Promise<APIResponse<TransferResponseV3>>
-⋮----
-/**
-   * Main-Sub Account Transfer
-   */
-subAccountTransfer(params: SubAccountTransferRequestV3): Promise<
-    APIResponse<{
-      transferId: string;
-      clientOid: string;
-    }>
-  > {
-    return this.postPrivate('/api/v3/account/sub-transfer', params);
-⋮----
-/**
-   * Get Main-Sub Transfer Records
-   */
-getSubTransferRecords(params?: GetSubTransferRecordsRequestV3): Promise<
-    APIResponse<{
-      items: SubTransferRecordV3[];
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/account/sub-transfer-record', params);
-⋮----
-/**
-   *
-   * =====Deposit======= endpoints
-   *
-   */
-⋮----
-/**
-   * Get Deposit Address
-   */
-getDepositAddress(
-    params: GetDepositAddressRequestV3,
-): Promise<APIResponse<DepositAddressV3>>
-⋮----
-/**
-   * Get Sub Deposit Address
-   */
-getSubDepositAddress(
-    params: GetSubDepositAddressRequestV3,
-): Promise<APIResponse<DepositAddressV3>>
-⋮----
-/**
-   * Get Deposit Records
-   */
-getDepositRecords(
-    params: GetDepositRecordsRequestV3,
-): Promise<APIResponse<DepositRecordV3[]>>
-⋮----
-/**
-   * Get Sub Deposit Records
-   */
-getSubDepositRecords(
-    params: GetSubDepositRecordsRequestV3,
-): Promise<APIResponse<DepositRecordV3[]>>
-⋮----
-/**
-   *
-   * =====Withdraw======= endpoints
-   *
-   */
-⋮----
-/**
-   * Withdraw - Includes on-chain withdrawals and internal transfers
-   */
-submitWithdraw(
-    params: WithdrawRequestV3,
-): Promise<APIResponse<WithdrawResponseV3>>
-⋮----
-/**
-   * Get Withdraw Records
-   */
-getWithdrawRecords(
-    params: GetWithdrawRecordsRequestV3,
-): Promise<APIResponse<WithdrawRecordV3[]>>
-⋮----
-/**
-   *
-   * =====Trade======= endpoints
-   *
-   */
-⋮----
-/**
-   * Place Order
-   */
-submitNewOrder(
-    params: PlaceOrderRequestV3,
-): Promise<APIResponse<PlaceOrderResponseV3>>
-⋮----
-/**
-   * Modify Order
-   */
-modifyOrder(
-    params: ModifyOrderRequestV3,
-): Promise<APIResponse<ModifyOrderResponseV3>>
-⋮----
-/**
-   * Cancel Order
-   */
-cancelOrder(
-    params: CancelOrderRequestV3,
-): Promise<APIResponse<CancelOrderResponseV3>>
-⋮----
-/**
-   * Batch Order
-   */
-placeBatchOrders(
-    params: PlaceBatchOrdersRequestV3[],
-): Promise<APIResponse<PlaceBatchOrdersResponseV3[]>>
-⋮----
-/**
-   * Batch Modify Orders
-   */
-batchModifyOrders(
-    params: BatchModifyOrderRequestV3[],
-): Promise<APIResponse<BatchModifyOrderResponseV3[]>>
-⋮----
-/**
-   * Batch Cancel
-   */
-cancelBatchOrders(
-    params: CancelBatchOrdersRequestV3[],
-): Promise<APIResponse<CancelBatchOrdersResponseV3[]>>
-⋮----
-/**
-   * Cancel All Orders
-   */
-cancelAllOrders(
-    params: CancelAllOrdersRequestV3,
-): Promise<APIResponse<CancelAllOrdersResponseV3>>
-⋮----
-/**
-   * Close All Positions
-   */
-closeAllPositions(
-    params: CloseAllPositionsRequestV3,
-): Promise<APIResponse<CloseAllPositionsResponseV3>>
-⋮----
-/**
-   * Get Order Details
-   */
-getOrderInfo(
-    params: GetOrderInfoRequestV3,
-): Promise<APIResponse<OrderInfoV3>>
-⋮----
-/**
-   * Get Open Orders
-   */
-getUnfilledOrders(params?: GetUnfilledOrdersRequestV3): Promise<
-    APIResponse<{
-      list: UnfilledOrderV3[];
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/trade/unfilled-orders', params);
-⋮----
-/**
-   * Get Order History
-   */
-getHistoryOrders(params: GetHistoryOrdersRequestV3): Promise<
-    APIResponse<{
-      list: HistoryOrderV3[];
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/trade/history-orders', params);
-⋮----
-/**
-   * Get Fill History
-   */
-getTradeFills(params?: GetFillsRequestV3): Promise<
-    APIResponse<{
-      list: FillV3[];
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/trade/fills', params);
-⋮----
-/**
-   * Get Position Info
-   */
-getCurrentPosition(params: GetCurrentPositionRequestV3): Promise<
-    APIResponse<{
-      list: CurrentPositionV3[];
-    }>
-  > {
-    return this.getPrivate('/api/v3/position/current-position', params);
-⋮----
-/**
-   * Get Positions History
-   */
-getPositionHistory(params: GetPositionHistoryRequestV3): Promise<
-    APIResponse<{
-      list: PositionHistoryV3[];
-      cursor: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/position/history-position', params);
-⋮----
-/**
-   * Get Max Open Available
-   */
-getMaxOpenAvailable(
-    params: GetMaxOpenAvailableRequestV3,
-): Promise<APIResponse<GetMaxOpenAvailableResponseV3>>
-⋮----
-/**
-   * Get Position ADL Rank - Get position auto-deleveraging ranking
-   */
-getPositionAdlRank(): Promise<APIResponse<PositionAdlRankV3[]>>
-⋮----
-/**
-   * CountDown Cancel All
-   */
-countdownCancelAll(
-    params: CountdownCancelAllRequestV3,
-): Promise<APIResponse<string>>
-⋮----
-/**
-   *
-   * =====Inst Loan======= endpoints
-   *
-   */
-⋮----
-/**
-   * Get Transferred Quantity
-   */
-getLoanTransfered(
-    params: GetTransferedRequestV3,
-): Promise<APIResponse<LoanTransfersV3>>
-⋮----
-/**
-   * Get Trade Symbols
-   */
-getLoanSymbols(
-    params: GetSymbolsRequestV3,
-): Promise<APIResponse<LoanSymbolsV3>>
-⋮----
-/**
-   * Get Risk Unit
-   */
-getLoanRiskUnit(): Promise<
-    APIResponse<{
-      riskUnitId: string[];
-    }>
-  > {
-    return this.getPrivate('/api/v3/ins-loan/risk-unit');
-⋮----
-/**
-   * Get Repayment Orders
-   */
-getLoanRepaidHistory(
-    params?: GetRepaidHistoryRequestV3,
-): Promise<APIResponse<RepaidHistoryItemV3[]>>
-⋮----
-/**
-   * Get Product Info
-   */
-getLoanProductInfo(
-    params: GetProductInfosRequestV3,
-): Promise<APIResponse<LoanProductInfoV3>>
-⋮----
-/**
-   * Get Loan Orders
-   */
-getLoanOrder(
-    params?: GetLoanOrderRequestV3,
-): Promise<APIResponse<LoanOrderV3[]>>
-⋮----
-/**
-   * Get LTV
-   */
-getLoanLTVConvert(
-    params?: GetLTVConvertRequestV3,
-): Promise<APIResponse<LTVConvertResponseV3>>
-⋮----
-/**
-   * Get Margin Coin Info
-   */
-getLoanMarginCoinInfo(params: GetEnsureCoinsRequestV3): Promise<
-    APIResponse<{
-      productId: string;
-      coinInfo: CoinInfoV3[];
-    }>
-  > {
-    return this.getPrivate('/api/v3/ins-loan/ensure-coins-convert', params);
-⋮----
-/**
-   * Bind/Unbind UID to Risk Unit
-   */
-bindLoanUid(
-    params: BindUidRequestV3,
-): Promise<APIResponse<BindUidResponseV3>>
-⋮----
-/**
-   *
-   * =====Strategy======= endpoints
-   *
-   */
-⋮----
-/**
-   * Place Strategy Order
-   */
-submitStrategyOrder(
-    params: PlaceStrategyOrderRequestV3,
-): Promise<APIResponse<PlaceStrategyOrderResponseV3>>
-⋮----
-/**
-   * Modify Strategy Order
-   */
-modifyStrategyOrder(
-    params: ModifyStrategyOrderRequestV3,
-): Promise<APIResponse<ModifyStrategyOrderResponseV3>>
-⋮----
-/**
-   * Cancel Strategy Order
-   */
-cancelStrategyOrder(
-    params: CancelStrategyOrderRequestV3,
-): Promise<APIResponse<null>>
-⋮----
-/**
-   * Get Unfilled Strategy Orders
-   */
-getUnfilledStrategyOrders(
-    params: GetUnfilledStrategyOrdersRequestV3,
-): Promise<APIResponse<StrategyOrderV3[]>>
-⋮----
-/**
-   * Get Strategy Order History
-   */
-getHistoryStrategyOrders(params: GetHistoryStrategyOrdersRequestV3): Promise<
-    APIResponse<{
-      list: StrategyOrderV3[];
-      cursor?: string;
-    }>
-  > {
-    return this.getPrivate('/api/v3/trade/history-strategy-orders', params);
-
-================
 File: package.json
 ================
 {
   "name": "bitget-api",
-  "version": "3.0.7",
+  "version": "3.0.11",
   "description": "Complete Node.js & JavaScript SDK for Bitget V1-V3 REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "scripts": {
     "test": "jest",
@@ -14606,7 +15110,7 @@ File: package.json
   "author": "Tiago Siebler (https://github.com/tiagosiebler)",
   "contributors": [],
   "dependencies": {
-    "axios": "^1.12.0",
+    "axios": "^1.12.2",
     "isomorphic-ws": "^5.0.0",
     "ws": "^8.18.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitget-api",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitget-api",
-      "version": "3.0.10",
+      "version": "3.0.11",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitget-api",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Complete Node.js & JavaScript SDK for Bitget V1-V3 REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "scripts": {
     "test": "jest",

--- a/src/rest-client-v3.ts
+++ b/src/rest-client-v3.ts
@@ -10,12 +10,14 @@ import {
   GetFinancialRecordsRequestV3,
   GetFundingAssetsRequestV3,
   GetMaxTransferableRequestV3,
+  GetOpenInterestLimitRequestV3,
   GetSubAccountApiKeysRequestV3,
   GetSubAccountListRequestV3,
   GetSubDepositAddressRequestV3,
   GetSubDepositRecordsRequestV3,
   GetSubTransferRecordsRequestV3,
   GetSubUnifiedAssetsRequestV3,
+  GetTaxRecordsRequestV3,
   GetTransferableCoinsRequestV3,
   GetWithdrawRecordsRequestV3,
   RepayRequestV3,
@@ -89,6 +91,7 @@ import {
   FinancialRecordV3,
   FundingAssetV3,
   MaxTransferableV3,
+  OpenInterestLimitV3,
   PaymentCoinV3,
   RepayableCoinV3,
   RepayResponseV3,
@@ -96,6 +99,7 @@ import {
   SubAccountV3,
   SubTransferRecordV3,
   SubUnifiedAssetV3,
+  TaxRecordV3,
   TransferResponseV3,
   UpdateSubAccountApiKeyResponseV3,
   WithdrawRecordV3,
@@ -301,6 +305,7 @@ export class RestClientV3 extends BaseRestClient {
 
   /**
    * Get Kline/Candlestick
+   * Maximum number of returned entries: 1,000
    */
   getCandles(
     params: GetCandlesRequestV3,
@@ -534,6 +539,18 @@ export class RestClientV3 extends BaseRestClient {
   }
 
   /**
+   * Get Open Interest Limit
+   *
+   * - Rate limit: 5/sec/UID
+   * - Get open interest limit for a symbol
+   */
+  getOpenInterestLimit(
+    params: GetOpenInterestLimitRequestV3,
+  ): Promise<APIResponse<OpenInterestLimitV3>> {
+    return this.getPrivate('/api/v3/account/open-interest-limit', params);
+  }
+
+  /**
    * Switch Account - Switch to classic account mode
    * Only supports parent accounts.
    * This endpoint is only used for switching to classic account mode.
@@ -556,6 +573,20 @@ export class RestClientV3 extends BaseRestClient {
     }>
   > {
     return this.getPrivate('/api/v3/account/switch-status');
+  }
+
+  /**
+   * Get Tax Records
+   *
+   * - Rate limit: 1/sec/UID
+   * - Data query range: 366 days
+   * - Please use the tax API Key to request Creation Portal
+   * - Get Unified Account Tax Records
+   */
+  getTaxRecords(
+    params: GetTaxRecordsRequestV3,
+  ): Promise<APIResponse<TaxRecordV3[]>> {
+    return this.getPrivate('/api/v3/tax/records', params);
   }
 
   /**

--- a/src/types/request/v3/account.ts
+++ b/src/types/request/v3/account.ts
@@ -259,3 +259,24 @@ export interface SetDepositAccountRequestV3 {
 export interface GetMaxTransferableRequestV3 {
   coin: string;
 }
+
+export interface GetOpenInterestLimitRequestV3 {
+  symbol: string;
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+}
+
+export interface GetTaxRecordsRequestV3 {
+  bizType:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES'
+    | 'OTHER';
+  marginType?: 'isolated' | 'crossed';
+  coin?: string;
+  startTime: string;
+  endTime: string;
+  limit?: string;
+  cursor?: string;
+}

--- a/src/types/response/v2/futures.ts
+++ b/src/types/response/v2/futures.ts
@@ -153,6 +153,7 @@ export interface FuturesContractConfigV2 {
   maxLever: string;
   posLimit: string;
   maintainTime: string;
+  isRwa: string;
 }
 
 /**
@@ -480,6 +481,7 @@ export interface FuturesHistoryOrderV2 {
   uTime: string;
   presetStopSurplusPrice: string;
   presetStopLossPrice: string;
+  liqPrice: string;
 }
 
 export interface FuturesCancelAllOrdersV2 {

--- a/src/types/response/v3/account.ts
+++ b/src/types/response/v3/account.ts
@@ -233,3 +233,20 @@ export interface MaxTransferableV3 {
   maxTransfer: string;
   borrowMaxTransfer: string;
 }
+
+export interface OpenInterestLimitV3 {
+  symbol: string;
+  singleUserLimit: string;
+  masterSubLimit: string;
+  marketMakerLimit: string;
+}
+
+export interface TaxRecordV3 {
+  id: string;
+  coin: string;
+  type: string;
+  amount: string;
+  fee: string;
+  balance: string;
+  ts: string;
+}

--- a/src/types/response/v3/loan.ts
+++ b/src/types/response/v3/loan.ts
@@ -12,6 +12,7 @@ export interface LoanSymbolSettingV3 {
 export interface LoanSymbolsV3 {
   productId: string;
   spotSymbols: string[];
+  marginLeverage: string;
   usdtContractLeverage: string;
   coinContractLeverage: string;
   usdcContractLeverage: string;

--- a/src/types/response/v3/public.ts
+++ b/src/types/response/v3/public.ts
@@ -104,7 +104,13 @@ export interface InstrumentV3 {
   minOrderAmount: string;
   maxSymbolOrderNum: string;
   maxProductOrderNum: string;
-  status: 'listed' | 'online' | 'limit_open' | 'offline' | 'restrictedAPI';
+  status:
+    | 'listed'
+    | 'online'
+    | 'limit_open'
+    | 'limit_close'
+    | 'offline'
+    | 'restrictedAPI';
   offTime: string;
   limitOpenTime: string;
   maintainTime: string;


### PR DESCRIPTION
Summary of Changes
rest-client-v2.ts updates:
Added liqPrice field to FuturesHistoryOrderV2 type (for /api/v2/mix/order/orders-history)
Added isRwa field to FuturesContractConfigV2 type (for /api/v2/mix/market/contracts)
rest-client-v3.ts updates:
Added marginLeverage field to LoanSymbolsV3 type (for /api/v3/ins-loan/symbols)
Updated getCandles comment to note maximum returned entries: 1,000
Added new endpoint getOpenInterestLimit (for /api/v3/account/open-interest-limit)
Created GetOpenInterestLimitRequestV3 request type
Created OpenInterestLimitV3 response type
Added limit_close to status enum in InstrumentV3 type (for /api/v3/market/instruments)
Added new endpoint getTaxRecords (for /api/v3/tax/records)
Created GetTaxRecordsRequestV3 request type
Created TaxRecordV3 response type