### PR TITLE
feat(v3.1.10): Add new API endpoints for liquidations, RPI data, and margin statistics

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -348,153 +348,177 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getServerTime()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L365) |  | GET | `/api/v3/public/time` |
-| [getInstruments()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L382) |  | GET | `/api/v3/market/instruments` |
-| [getMarketFeeGroup()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L391) |  | GET | `/api/v3/market/fee-group` |
-| [getMarketScoreWeights()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L400) |  | GET | `/api/v3/market/score-weights` |
-| [getTickers()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L409) |  | GET | `/api/v3/market/tickers` |
-| [getOrderBook()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L416) |  | GET | `/api/v3/market/orderbook` |
-| [getFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L425) |  | GET | `/api/v3/market/fills` |
-| [getProofOfReserves()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L434) |  | GET | `/api/v3/market/proof-of-reserves` |
-| [getOpenInterest()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L441) |  | GET | `/api/v3/market/open-interest` |
-| [getCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L451) |  | GET | `/api/v3/market/candles` |
-| [getHistoryCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L460) |  | GET | `/api/v3/market/history-candles` |
-| [getCurrentFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L469) |  | GET | `/api/v3/market/current-fund-rate` |
-| [getHistoryFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L478) |  | GET | `/api/v3/market/history-fund-rate` |
-| [getRiskReserve()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L487) |  | GET | `/api/v3/market/risk-reserve` |
-| [getRiskReserveHour()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L496) |  | GET | `/api/v3/market/risk-reserve-hour` |
-| [getRiskReserveAll()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L505) |  | GET | `/api/v3/market/risk-reserve-all` |
-| [getDiscountRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L514) |  | GET | `/api/v3/market/discount-rate` |
-| [getMarginLoans()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L521) |  | GET | `/api/v3/market/margin-loans` |
-| [getPositionTier()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L530) |  | GET | `/api/v3/market/position-tier` |
-| [getContractsOi()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L539) |  | GET | `/api/v3/market/oi-limit` |
-| [getIndexComponents()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L548) |  | GET | `/api/v3/market/index-components` |
-| [getCopyFuturesTradingPairs()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L565) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/trading-pairs` |
-| [getCopyFuturesPositionSummary()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L576) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/position-summary` |
-| [getCopyFuturesMaxTransferable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L586) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/max-transferable` |
-| [copyFuturesTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L596) | :closed_lock_with_key:  | POST | `/api/v3/copy/futures/transfer` |
-| [getCopyFuturesTransferRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L606) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/transfer-record` |
-| [getBalances()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L621) | :closed_lock_with_key:  | GET | `/api/v3/account/assets` |
-| [getFundingAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L628) | :closed_lock_with_key:  | GET | `/api/v3/account/funding-assets` |
-| [getAccountInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L638) | :closed_lock_with_key:  | GET | `/api/v3/account/info` |
-| [getAccountSettings()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L646) | :closed_lock_with_key:  | GET | `/api/v3/account/settings` |
-| [adjustAccountMode()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L653) | :closed_lock_with_key:  | POST | `/api/v3/account/adjust-account-mode` |
-| [getDeltaInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L663) | :closed_lock_with_key:  | GET | `/api/v3/account/delta-info` |
-| [setLeverage()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L670) | :closed_lock_with_key:  | POST | `/api/v3/account/set-leverage` |
-| [setHoldMode()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L677) | :closed_lock_with_key:  | POST | `/api/v3/account/set-hold-mode` |
-| [getFinancialRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L686) | :closed_lock_with_key:  | GET | `/api/v3/account/financial-records` |
-| [getRepayableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L698) | :closed_lock_with_key:  | GET | `/api/v3/account/repayable-coins` |
-| [getPaymentCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L710) | :closed_lock_with_key:  | GET | `/api/v3/account/payment-coins` |
-| [submitRepay()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L722) | :closed_lock_with_key:  | POST | `/api/v3/account/repay` |
-| [getConvertRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L729) | :closed_lock_with_key:  | GET | `/api/v3/account/convert-records` |
-| [setDepositAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L744) | :closed_lock_with_key:  | POST | `/api/v3/account/deposit-account` |
-| [switchDeduct()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L753) | :closed_lock_with_key:  | POST | `/api/v3/account/switch-deduct` |
-| [getDeductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L760) | :closed_lock_with_key:  | GET | `/api/v3/account/deduct-info` |
-| [getFeeRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L771) | :closed_lock_with_key:  | GET | `/api/v3/account/fee-rate` |
-| [getMaxTransferable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L787) | :closed_lock_with_key:  | GET | `/api/v3/account/max-transferable` |
-| [getOpenInterestLimit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L799) | :closed_lock_with_key:  | GET | `/api/v3/account/open-interest-limit` |
-| [downgradeAccountToClassic()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L814) | :closed_lock_with_key:  | POST | `/api/v3/account/switch` |
-| [getUnifiedAccountSwitchStatus()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L822) | :closed_lock_with_key:  | GET | `/api/v3/account/switch-status` |
-| [getTaxRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L838) | :closed_lock_with_key:  | GET | `/api/v3/tax/records` |
-| [createSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L853) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub` |
-| [freezeSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L862) | :closed_lock_with_key:  | POST | `/api/v3/user/freeze-sub` |
-| [getSubUnifiedAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L871) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-unified-assets` |
-| [getSubAccountList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L880) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-list` |
-| [createSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L893) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub-api` |
-| [updateSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L902) | :closed_lock_with_key:  | POST | `/api/v3/user/update-sub-api` |
-| [deleteSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L911) | :closed_lock_with_key:  | POST | `/api/v3/user/delete-sub-api` |
-| [getSubAccountApiKeys()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L920) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-api-list` |
-| [getTransferableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L939) | :closed_lock_with_key:  | GET | `/api/v3/account/transferable-coins` |
-| [submitTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L948) | :closed_lock_with_key:  | POST | `/api/v3/account/transfer` |
-| [subAccountTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L957) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-transfer` |
-| [getSubTransferRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L969) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-transfer-record` |
-| [getDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L987) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-address` |
-| [getSubDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L996) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-deposit-address` |
-| [getDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1005) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-records` |
-| [getSubDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1014) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-deposit-records` |
-| [submitWithdraw()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1029) | :closed_lock_with_key:  | POST | `/api/v3/account/withdraw` |
-| [getWithdrawRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1038) | :closed_lock_with_key:  | GET | `/api/v3/account/withdrawal-records` |
-| [getWithdrawAddressBook()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1047) | :closed_lock_with_key:  | GET | `/api/v3/account/withdraw-address` |
-| [cancelWithdrawal()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1056) | :closed_lock_with_key:  | POST | `/api/v3/account/cancel-withdrawal` |
-| [submitNewOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1071) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-order` |
-| [modifyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1080) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-order` |
-| [cancelOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1089) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-order` |
-| [placeBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1098) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-batch` |
-| [batchModifyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1107) | :closed_lock_with_key:  | POST | `/api/v3/trade/batch-modify-order` |
-| [cancelBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1116) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-batch` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1125) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-symbol-order` |
-| [closeAllPositions()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1134) | :closed_lock_with_key:  | POST | `/api/v3/trade/close-positions` |
-| [getOrderInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1143) | :closed_lock_with_key:  | GET | `/api/v3/trade/order-info` |
-| [getUnfilledOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1152) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-orders` |
-| [getHistoryOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1164) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-orders` |
-| [getTradeFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1176) | :closed_lock_with_key:  | GET | `/api/v3/trade/fills` |
-| [getCurrentPosition()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1188) | :closed_lock_with_key:  | GET | `/api/v3/position/current-position` |
-| [getPositionHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1199) | :closed_lock_with_key:  | GET | `/api/v3/position/history-position` |
-| [getMaxOpenAvailable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1211) | :closed_lock_with_key:  | POST | `/api/v3/account/max-open-available` |
-| [getPositionAdlRank()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1220) | :closed_lock_with_key:  | GET | `/api/v3/position/adlRank` |
-| [countdownCancelAll()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1227) | :closed_lock_with_key:  | POST | `/api/v3/trade/countdown-cancel-all` |
-| [getLoanTransfered()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1242) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/transfered` |
-| [getLoanSymbols()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1251) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/symbols` |
-| [getLoanRiskUnit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1260) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/risk-unit` |
-| [getLoanRepaidHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1271) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/repaid-history` |
-| [getLoanProductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1280) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/product-infos` |
-| [getLoanOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1289) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/loan-order` |
-| [getLoanLTVConvert()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1298) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ltv-convert` |
-| [getLoanMarginCoinInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1307) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ensure-coins-convert` |
-| [bindLoanUid()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1319) | :closed_lock_with_key:  | POST | `/api/v3/ins-loan/bind-uid` |
-| [getLoanCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1334) | :closed_lock_with_key:  | GET | `/api/v3/loan/coins` |
-| [getLoanInterest()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1343) | :closed_lock_with_key:  | GET | `/api/v3/loan/interest` |
-| [loanBorrow()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1352) | :closed_lock_with_key:  | POST | `/api/v3/loan/borrow` |
-| [getLoanBorrowOngoing()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1361) | :closed_lock_with_key:  | GET | `/api/v3/loan/borrow-ongoing` |
-| [getLoanBorrowHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1370) | :closed_lock_with_key:  | GET | `/api/v3/loan/borrow-history` |
-| [loanRepay()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1379) | :closed_lock_with_key:  | POST | `/api/v3/loan/repay` |
-| [getLoanRepayHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1388) | :closed_lock_with_key:  | GET | `/api/v3/loan/repay-history` |
-| [loanRevisePledge()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1397) | :closed_lock_with_key:  | POST | `/api/v3/loan/revise-pledge` |
-| [getLoanPledgeRateHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1406) | :closed_lock_with_key:  | GET | `/api/v3/loan/pledge-rate-history` |
-| [getLoanDebts()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1415) | :closed_lock_with_key:  | GET | `/api/v3/loan/debts` |
-| [getLoanReduces()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1422) | :closed_lock_with_key:  | GET | `/api/v3/loan/reduces` |
-| [submitStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1437) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-strategy-order` |
-| [modifyStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1446) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-strategy-order` |
-| [cancelStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1455) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-strategy-order` |
-| [getUnfilledStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1464) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-strategy-orders` |
-| [getHistoryStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1473) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-strategy-orders` |
-| [createBrokerSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1494) | :closed_lock_with_key:  | POST | `/api/v3/broker/create-sub` |
-| [getBrokerSubAccountList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1506) | :closed_lock_with_key:  | GET | `/api/v3/broker/sub-list` |
-| [modifyBrokerSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1518) | :closed_lock_with_key:  | POST | `/api/v3/broker/modify-sub` |
-| [brokerSubWithdrawal()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1533) | :closed_lock_with_key:  | POST | `/api/v3/broker/sub-withdrawal` |
-| [getBrokerSubDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1545) | :closed_lock_with_key:  | POST | `/api/v3/broker/sub-deposit-address` |
-| [getBrokerAllSubDepositWithdrawal()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1557) | :closed_lock_with_key:  | GET | `/api/v3/broker/all-sub-deposit-withdrawal` |
-| [getBrokerCommission()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1569) | :closed_lock_with_key:  | GET | `/api/v3/broker/commission` |
-| [createBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1581) | :closed_lock_with_key:  | POST | `/api/v3/broker/create-sub-apikey` |
-| [modifyBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1593) | :closed_lock_with_key:  | POST | `/api/v3/broker/modify-sub-apikey` |
-| [deleteBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1609) | :closed_lock_with_key:  | POST | `/api/v3/broker/delete-sub-apikey` |
-| [getBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1621) | :closed_lock_with_key:  | GET | `/api/v3/broker/query-sub-apikey` |
-| [getP2pAdList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1633) | :closed_lock_with_key:  | GET | `/api/v3/p2p/ad-list` |
-| [getP2pExchangeRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1639) | :closed_lock_with_key:  | GET | `/api/v3/p2p/exchange-rate` |
-| [simulateP2pFee()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1645) | :closed_lock_with_key:  | POST | `/api/v3/p2p/fee-simulate` |
-| [getP2pAdLimit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1651) | :closed_lock_with_key:  | GET | `/api/v3/p2p/ad-limit` |
-| [createP2pAd()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1657) | :closed_lock_with_key:  | POST | `/api/v3/p2p/ad-create` |
-| [updateP2pAd()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1663) | :closed_lock_with_key:  | POST | `/api/v3/p2p/ad-update` |
-| [operateP2pAd()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1667) | :closed_lock_with_key:  | POST | `/api/v3/p2p/ad-operate` |
-| [getP2pAdInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1671) | :closed_lock_with_key:  | GET | `/api/v3/p2p/ad-info` |
-| [getP2pMyAds()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1677) | :closed_lock_with_key:  | GET | `/api/v3/p2p/my-ads` |
-| [getP2pPendingOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1683) | :closed_lock_with_key:  | GET | `/api/v3/p2p/pending-orders` |
-| [getP2pAllOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1689) | :closed_lock_with_key:  | GET | `/api/v3/p2p/all-orders` |
-| [getP2pOrderInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1695) | :closed_lock_with_key:  | GET | `/api/v3/p2p/order-info` |
-| [confirmP2pOrderPayment()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1701) | :closed_lock_with_key:  | POST | `/api/v3/p2p/order-pay` |
-| [releaseP2pOrderAsset()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1707) | :closed_lock_with_key:  | POST | `/api/v3/p2p/order-release` |
-| [getP2pUserInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1713) | :closed_lock_with_key:  | GET | `/api/v3/p2p/user-info` |
-| [getP2pCurrencies()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1717) | :closed_lock_with_key:  | GET | `/api/v3/p2p/currencies` |
-| [getP2pPayMethods()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1721) | :closed_lock_with_key:  | GET | `/api/v3/p2p/pay-method` |
-| [getP2pBalance()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1725) | :closed_lock_with_key:  | GET | `/api/v3/p2p/balance` |
-| [getEarnEliteProducts()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1737) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-product` |
-| [getEarnEliteAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1741) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-assets` |
-| [getEarnEliteRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1745) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-records` |
-| [getEarnEliteSubscribeInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1751) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-subscribe-info` |
-| [subscribeEarnElite()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1757) | :closed_lock_with_key:  | POST | `/api/v3/earn/elite-subscribe` |
-| [getEarnEliteSubscribeResult()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1763) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-subscribe-result` |
-| [getEarnEliteRedeemInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1769) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-redeem-info` |
-| [redeemEarnElite()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1775) | :closed_lock_with_key:  | POST | `/api/v3/earn/elite-redeem` |
+| [getServerTime()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L402) |  | GET | `/api/v3/public/time` |
+| [getInstruments()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L419) |  | GET | `/api/v3/market/instruments` |
+| [getMarketFeeGroup()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L428) |  | GET | `/api/v3/market/fee-group` |
+| [getLiquidations()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L437) |  | GET | `/api/v3/market/liquidations` |
+| [getRpiSymbols()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L446) |  | GET | `/api/v3/market/rpi-symbols` |
+| [getRpiOrderBook()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L453) |  | GET | `/api/v3/market/rpi-orderbook` |
+| [getCashDividendRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L462) |  | GET | `/api/v3/market/cash-dividend-records` |
+| [getSpotWhaleFlow()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L471) |  | GET | `/api/v3/market/spot-whale-flow` |
+| [getSpotFundFlow()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L480) |  | GET | `/api/v3/market/spot-fund-flow` |
+| [getSpotNetFlow()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L489) |  | GET | `/api/v3/market/spot-net-flow` |
+| [getMarginLongShort()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L498) |  | GET | `/api/v3/market/margin-long-short` |
+| [getMarginLoanGrowth()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L507) |  | GET | `/api/v3/market/margin-loan-growth` |
+| [getMarginIsolatedBorrow()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L516) |  | GET | `/api/v3/market/margin-isolated-borrow` |
+| [getFuturesActiveBuySell()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L525) |  | GET | `/api/v3/market/futures-active-buy-sell` |
+| [getFuturesLongShort()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L534) |  | GET | `/api/v3/market/futures-long-short` |
+| [getFuturesPositionLongShort()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L543) |  | GET | `/api/v3/market/futures-position-long-short` |
+| [getFuturesAccountLongShort()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L552) |  | GET | `/api/v3/market/futures-account-long-short` |
+| [getMarketScoreWeights()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L561) |  | GET | `/api/v3/market/score-weights` |
+| [getTickers()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L570) |  | GET | `/api/v3/market/tickers` |
+| [getOrderBook()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L577) |  | GET | `/api/v3/market/orderbook` |
+| [getFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L586) |  | GET | `/api/v3/market/fills` |
+| [getProofOfReserves()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L595) |  | GET | `/api/v3/market/proof-of-reserves` |
+| [getOpenInterest()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L602) |  | GET | `/api/v3/market/open-interest` |
+| [getCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L612) |  | GET | `/api/v3/market/candles` |
+| [getHistoryCandles()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L621) |  | GET | `/api/v3/market/history-candles` |
+| [getCurrentFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L630) |  | GET | `/api/v3/market/current-fund-rate` |
+| [getHistoryFundingRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L639) |  | GET | `/api/v3/market/history-fund-rate` |
+| [getRiskReserve()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L648) |  | GET | `/api/v3/market/risk-reserve` |
+| [getRiskReserveHour()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L657) |  | GET | `/api/v3/market/risk-reserve-hour` |
+| [getRiskReserveAll()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L666) |  | GET | `/api/v3/market/risk-reserve-all` |
+| [getDiscountRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L675) |  | GET | `/api/v3/market/discount-rate` |
+| [getMarginLoans()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L682) |  | GET | `/api/v3/market/margin-loans` |
+| [getPositionTier()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L691) |  | GET | `/api/v3/market/position-tier` |
+| [getContractsOi()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L700) |  | GET | `/api/v3/market/oi-limit` |
+| [getIndexComponents()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L709) |  | GET | `/api/v3/market/index-components` |
+| [getCopyFuturesTradingPairs()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L726) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/trading-pairs` |
+| [getCopyFuturesPositionSummary()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L737) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/position-summary` |
+| [getCopyFuturesMaxTransferable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L747) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/max-transferable` |
+| [copyFuturesTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L757) | :closed_lock_with_key:  | POST | `/api/v3/copy/futures/transfer` |
+| [getCopyFuturesTransferRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L767) | :closed_lock_with_key:  | GET | `/api/v3/copy/futures/transfer-record` |
+| [getBalances()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L782) | :closed_lock_with_key:  | GET | `/api/v3/account/assets` |
+| [getFundingAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L789) | :closed_lock_with_key:  | GET | `/api/v3/account/funding-assets` |
+| [getAccountInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L799) | :closed_lock_with_key:  | GET | `/api/v3/account/info` |
+| [getAccountSettings()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L807) | :closed_lock_with_key:  | GET | `/api/v3/account/settings` |
+| [adjustAccountMode()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L814) | :closed_lock_with_key:  | POST | `/api/v3/account/adjust-account-mode` |
+| [getDeltaInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L824) | :closed_lock_with_key:  | GET | `/api/v3/account/delta-info` |
+| [setLeverage()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L831) | :closed_lock_with_key:  | POST | `/api/v3/account/set-leverage` |
+| [setHoldMode()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L838) | :closed_lock_with_key:  | POST | `/api/v3/account/set-hold-mode` |
+| [getCollateralType()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L847) | :closed_lock_with_key:  | GET | `/api/v3/account/collateral-type` |
+| [setCollateralType()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L854) | :closed_lock_with_key:  | POST | `/api/v3/account/set-collateral-type` |
+| [getCustomCollateralCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L863) |  | GET | `/api/v3/account/custom-collateral-coins` |
+| [preSetLeverage()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L870) | :closed_lock_with_key:  | GET | `/api/v3/account/pre-set-leverage` |
+| [setMargin()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L879) | :closed_lock_with_key:  | POST | `/api/v3/account/set-margin` |
+| [getMaxWithdrawal()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L886) | :closed_lock_with_key:  | GET | `/api/v3/account/max-withdrawal` |
+| [getFinancialRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L895) | :closed_lock_with_key:  | GET | `/api/v3/account/financial-records` |
+| [getRepayableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L907) | :closed_lock_with_key:  | GET | `/api/v3/account/repayable-coins` |
+| [getPaymentCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L919) | :closed_lock_with_key:  | GET | `/api/v3/account/payment-coins` |
+| [submitRepay()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L931) | :closed_lock_with_key:  | POST | `/api/v3/account/repay` |
+| [getConvertRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L938) | :closed_lock_with_key:  | GET | `/api/v3/account/convert-records` |
+| [setDepositAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L953) | :closed_lock_with_key:  | POST | `/api/v3/account/deposit-account` |
+| [switchDeduct()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L962) | :closed_lock_with_key:  | POST | `/api/v3/account/switch-deduct` |
+| [getDeductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L969) | :closed_lock_with_key:  | GET | `/api/v3/account/deduct-info` |
+| [getFeeRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L980) | :closed_lock_with_key:  | GET | `/api/v3/account/fee-rate` |
+| [getAllFeeRates()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L992) | :closed_lock_with_key:  | GET | `/api/v3/account/all-fee-rate` |
+| [getMaxTransferable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1005) | :closed_lock_with_key:  | GET | `/api/v3/account/max-transferable` |
+| [getOpenInterestLimit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1017) | :closed_lock_with_key:  | GET | `/api/v3/account/open-interest-limit` |
+| [downgradeAccountToClassic()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1032) | :closed_lock_with_key:  | POST | `/api/v3/account/switch` |
+| [getUnifiedAccountSwitchStatus()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1040) | :closed_lock_with_key:  | GET | `/api/v3/account/switch-status` |
+| [getTaxRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1056) | :closed_lock_with_key:  | GET | `/api/v3/tax/records` |
+| [createSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1071) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub` |
+| [freezeSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1080) | :closed_lock_with_key:  | POST | `/api/v3/user/freeze-sub` |
+| [getSubUnifiedAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1089) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-unified-assets` |
+| [getSubAccountList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1098) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-list` |
+| [createSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1111) | :closed_lock_with_key:  | POST | `/api/v3/user/create-sub-api` |
+| [updateSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1120) | :closed_lock_with_key:  | POST | `/api/v3/user/update-sub-api` |
+| [deleteSubAccountApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1129) | :closed_lock_with_key:  | POST | `/api/v3/user/delete-sub-api` |
+| [getSubAccountApiKeys()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1138) | :closed_lock_with_key:  | GET | `/api/v3/user/sub-api-list` |
+| [getTransferableCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1157) | :closed_lock_with_key:  | GET | `/api/v3/account/transferable-coins` |
+| [submitTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1166) | :closed_lock_with_key:  | POST | `/api/v3/account/transfer` |
+| [subAccountTransfer()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1175) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-transfer` |
+| [getSubTransferRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1187) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-transfer-record` |
+| [getDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1205) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-address` |
+| [getSubDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1214) | :closed_lock_with_key:  | GET | `/api/v3/account/sub-deposit-address` |
+| [getDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1223) | :closed_lock_with_key:  | GET | `/api/v3/account/deposit-records` |
+| [getSubDepositRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1232) | :closed_lock_with_key:  | POST | `/api/v3/account/sub-deposit-records` |
+| [submitWithdraw()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1247) | :closed_lock_with_key:  | POST | `/api/v3/account/withdraw` |
+| [getWithdrawRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1256) | :closed_lock_with_key:  | GET | `/api/v3/account/withdrawal-records` |
+| [getWithdrawAddressBook()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1265) | :closed_lock_with_key:  | GET | `/api/v3/account/withdraw-address` |
+| [cancelWithdrawal()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1274) | :closed_lock_with_key:  | POST | `/api/v3/account/cancel-withdrawal` |
+| [submitNewOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1289) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-order` |
+| [modifyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1298) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-order` |
+| [placeRealityOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1307) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-reality-order` |
+| [cancelRealityOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1316) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-reality-order` |
+| [getLoanData()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1325) | :closed_lock_with_key:  | GET | `/api/v3/trade/loan-data` |
+| [cancelOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1332) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-order` |
+| [placeBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1341) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-batch` |
+| [batchModifyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1350) | :closed_lock_with_key:  | POST | `/api/v3/trade/batch-modify-order` |
+| [cancelBatchOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1359) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-batch` |
+| [cancelAllOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1368) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-symbol-order` |
+| [closeAllPositions()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1377) | :closed_lock_with_key:  | POST | `/api/v3/trade/close-positions` |
+| [getOrderInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1386) | :closed_lock_with_key:  | GET | `/api/v3/trade/order-info` |
+| [getUnfilledOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1395) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-orders` |
+| [getHistoryOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1407) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-orders` |
+| [getTradeFills()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1419) | :closed_lock_with_key:  | GET | `/api/v3/trade/fills` |
+| [getCurrentPosition()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1431) | :closed_lock_with_key:  | GET | `/api/v3/position/current-position` |
+| [getPositionHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1442) | :closed_lock_with_key:  | GET | `/api/v3/position/history-position` |
+| [getMaxOpenAvailable()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1454) | :closed_lock_with_key:  | POST | `/api/v3/account/max-open-available` |
+| [getPositionAdlRank()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1463) | :closed_lock_with_key:  | GET | `/api/v3/position/adlRank` |
+| [countdownCancelAll()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1470) | :closed_lock_with_key:  | POST | `/api/v3/trade/countdown-cancel-all` |
+| [getLoanTransfered()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1485) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/transfered` |
+| [getLoanSymbols()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1494) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/symbols` |
+| [getLoanRiskUnit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1503) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/risk-unit` |
+| [getLoanRepaidHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1514) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/repaid-history` |
+| [getLoanProductInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1523) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/product-infos` |
+| [getLoanOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1532) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/loan-order` |
+| [getLoanLTVConvert()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1541) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ltv-convert` |
+| [getLoanMarginCoinInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1550) | :closed_lock_with_key:  | GET | `/api/v3/ins-loan/ensure-coins-convert` |
+| [bindLoanUid()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1562) | :closed_lock_with_key:  | POST | `/api/v3/ins-loan/bind-uid` |
+| [getLoanCoins()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1577) | :closed_lock_with_key:  | GET | `/api/v3/loan/coins` |
+| [getLoanInterest()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1586) | :closed_lock_with_key:  | GET | `/api/v3/loan/interest` |
+| [loanBorrow()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1595) | :closed_lock_with_key:  | POST | `/api/v3/loan/borrow` |
+| [getLoanBorrowOngoing()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1604) | :closed_lock_with_key:  | GET | `/api/v3/loan/borrow-ongoing` |
+| [getLoanBorrowHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1613) | :closed_lock_with_key:  | GET | `/api/v3/loan/borrow-history` |
+| [loanRepay()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1622) | :closed_lock_with_key:  | POST | `/api/v3/loan/repay` |
+| [getLoanRepayHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1631) | :closed_lock_with_key:  | GET | `/api/v3/loan/repay-history` |
+| [loanRevisePledge()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1640) | :closed_lock_with_key:  | POST | `/api/v3/loan/revise-pledge` |
+| [getLoanPledgeRateHistory()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1649) | :closed_lock_with_key:  | GET | `/api/v3/loan/pledge-rate-history` |
+| [getLoanDebts()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1658) | :closed_lock_with_key:  | GET | `/api/v3/loan/debts` |
+| [getLoanReduces()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1665) | :closed_lock_with_key:  | GET | `/api/v3/loan/reduces` |
+| [submitStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1680) | :closed_lock_with_key:  | POST | `/api/v3/trade/place-strategy-order` |
+| [modifyStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1689) | :closed_lock_with_key:  | POST | `/api/v3/trade/modify-strategy-order` |
+| [cancelStrategyOrder()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1698) | :closed_lock_with_key:  | POST | `/api/v3/trade/cancel-strategy-order` |
+| [getUnfilledStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1707) | :closed_lock_with_key:  | GET | `/api/v3/trade/unfilled-strategy-orders` |
+| [getHistoryStrategyOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1716) | :closed_lock_with_key:  | GET | `/api/v3/trade/history-strategy-orders` |
+| [createBrokerSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1737) | :closed_lock_with_key:  | POST | `/api/v3/broker/create-sub` |
+| [getBrokerSubAccountList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1749) | :closed_lock_with_key:  | GET | `/api/v3/broker/sub-list` |
+| [modifyBrokerSubAccount()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1761) | :closed_lock_with_key:  | POST | `/api/v3/broker/modify-sub` |
+| [brokerSubWithdrawal()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1776) | :closed_lock_with_key:  | POST | `/api/v3/broker/sub-withdrawal` |
+| [getBrokerSubDepositAddress()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1788) | :closed_lock_with_key:  | POST | `/api/v3/broker/sub-deposit-address` |
+| [getBrokerAllSubDepositWithdrawal()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1800) | :closed_lock_with_key:  | GET | `/api/v3/broker/all-sub-deposit-withdrawal` |
+| [getBrokerCommission()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1812) | :closed_lock_with_key:  | GET | `/api/v3/broker/commission` |
+| [createBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1824) | :closed_lock_with_key:  | POST | `/api/v3/broker/create-sub-apikey` |
+| [modifyBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1836) | :closed_lock_with_key:  | POST | `/api/v3/broker/modify-sub-apikey` |
+| [deleteBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1852) | :closed_lock_with_key:  | POST | `/api/v3/broker/delete-sub-apikey` |
+| [getBrokerSubApiKey()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1864) | :closed_lock_with_key:  | GET | `/api/v3/broker/query-sub-apikey` |
+| [getP2pAdList()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1876) | :closed_lock_with_key:  | GET | `/api/v3/p2p/ad-list` |
+| [getP2pExchangeRate()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1882) | :closed_lock_with_key:  | GET | `/api/v3/p2p/exchange-rate` |
+| [simulateP2pFee()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1888) | :closed_lock_with_key:  | POST | `/api/v3/p2p/fee-simulate` |
+| [getP2pAdLimit()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1894) | :closed_lock_with_key:  | GET | `/api/v3/p2p/ad-limit` |
+| [createP2pAd()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1900) | :closed_lock_with_key:  | POST | `/api/v3/p2p/ad-create` |
+| [updateP2pAd()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1906) | :closed_lock_with_key:  | POST | `/api/v3/p2p/ad-update` |
+| [operateP2pAd()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1910) | :closed_lock_with_key:  | POST | `/api/v3/p2p/ad-operate` |
+| [getP2pAdInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1914) | :closed_lock_with_key:  | GET | `/api/v3/p2p/ad-info` |
+| [getP2pMyAds()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1920) | :closed_lock_with_key:  | GET | `/api/v3/p2p/my-ads` |
+| [getP2pPendingOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1926) | :closed_lock_with_key:  | GET | `/api/v3/p2p/pending-orders` |
+| [getP2pAllOrders()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1932) | :closed_lock_with_key:  | GET | `/api/v3/p2p/all-orders` |
+| [getP2pOrderInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1938) | :closed_lock_with_key:  | GET | `/api/v3/p2p/order-info` |
+| [confirmP2pOrderPayment()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1944) | :closed_lock_with_key:  | POST | `/api/v3/p2p/order-pay` |
+| [releaseP2pOrderAsset()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1950) | :closed_lock_with_key:  | POST | `/api/v3/p2p/order-release` |
+| [getP2pUserInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1956) | :closed_lock_with_key:  | GET | `/api/v3/p2p/user-info` |
+| [getP2pCurrencies()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1960) | :closed_lock_with_key:  | GET | `/api/v3/p2p/currencies` |
+| [getP2pPayMethods()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1964) | :closed_lock_with_key:  | GET | `/api/v3/p2p/pay-method` |
+| [getP2pBalance()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1968) | :closed_lock_with_key:  | GET | `/api/v3/p2p/balance` |
+| [getEarnEliteProducts()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1980) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-product` |
+| [getEarnEliteAssets()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1984) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-assets` |
+| [getEarnEliteRecords()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1988) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-records` |
+| [getEarnEliteSubscribeInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L1994) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-subscribe-info` |
+| [subscribeEarnElite()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L2000) | :closed_lock_with_key:  | POST | `/api/v3/earn/elite-subscribe` |
+| [getEarnEliteSubscribeResult()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L2006) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-subscribe-result` |
+| [getEarnEliteRedeemInfo()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L2012) | :closed_lock_with_key:  | GET | `/api/v3/earn/elite-redeem-info` |
+| [redeemEarnElite()](https://github.com/tiagosiebler/bitget-api/blob/master/src/rest-client-v3.ts#L2018) | :closed_lock_with_key:  | POST | `/api/v3/earn/elite-redeem` |
 
 # websocket-api-client.ts
 

--- a/examples/apidoc/RestClientV3/cancelRealityOrder.js
+++ b/examples/apidoc/RestClientV3/cancelRealityOrder.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/trade/cancel-reality-order
+// METHOD: POST
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.cancelRealityOrder(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getAllFeeRates.js
+++ b/examples/apidoc/RestClientV3/getAllFeeRates.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/all-fee-rate
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getAllFeeRates(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getCashDividendRecords.js
+++ b/examples/apidoc/RestClientV3/getCashDividendRecords.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/cash-dividend-records
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getCashDividendRecords(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getCollateralType.js
+++ b/examples/apidoc/RestClientV3/getCollateralType.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/collateral-type
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getCollateralType(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getCustomCollateralCoins.js
+++ b/examples/apidoc/RestClientV3/getCustomCollateralCoins.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/custom-collateral-coins
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getCustomCollateralCoins(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getFuturesAccountLongShort.js
+++ b/examples/apidoc/RestClientV3/getFuturesAccountLongShort.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/futures-account-long-short
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getFuturesAccountLongShort(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getFuturesActiveBuySell.js
+++ b/examples/apidoc/RestClientV3/getFuturesActiveBuySell.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/futures-active-buy-sell
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getFuturesActiveBuySell(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getFuturesLongShort.js
+++ b/examples/apidoc/RestClientV3/getFuturesLongShort.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/futures-long-short
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getFuturesLongShort(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getFuturesPositionLongShort.js
+++ b/examples/apidoc/RestClientV3/getFuturesPositionLongShort.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/futures-position-long-short
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getFuturesPositionLongShort(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getLiquidations.js
+++ b/examples/apidoc/RestClientV3/getLiquidations.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/liquidations
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getLiquidations(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getLoanData.js
+++ b/examples/apidoc/RestClientV3/getLoanData.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/trade/loan-data
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getLoanData(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getMarginIsolatedBorrow.js
+++ b/examples/apidoc/RestClientV3/getMarginIsolatedBorrow.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/margin-isolated-borrow
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getMarginIsolatedBorrow(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getMarginLoanGrowth.js
+++ b/examples/apidoc/RestClientV3/getMarginLoanGrowth.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/margin-loan-growth
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getMarginLoanGrowth(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getMarginLongShort.js
+++ b/examples/apidoc/RestClientV3/getMarginLongShort.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/margin-long-short
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getMarginLongShort(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getMaxWithdrawal.js
+++ b/examples/apidoc/RestClientV3/getMaxWithdrawal.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/max-withdrawal
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getMaxWithdrawal(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getRpiOrderBook.js
+++ b/examples/apidoc/RestClientV3/getRpiOrderBook.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/rpi-orderbook
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getRpiOrderBook(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getRpiSymbols.js
+++ b/examples/apidoc/RestClientV3/getRpiSymbols.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/rpi-symbols
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getRpiSymbols(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getSpotFundFlow.js
+++ b/examples/apidoc/RestClientV3/getSpotFundFlow.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/spot-fund-flow
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getSpotFundFlow(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getSpotNetFlow.js
+++ b/examples/apidoc/RestClientV3/getSpotNetFlow.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/spot-net-flow
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getSpotNetFlow(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/getSpotWhaleFlow.js
+++ b/examples/apidoc/RestClientV3/getSpotWhaleFlow.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/market/spot-whale-flow
+// METHOD: GET
+// PUBLIC: YES
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.getSpotWhaleFlow(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/placeRealityOrder.js
+++ b/examples/apidoc/RestClientV3/placeRealityOrder.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/trade/place-reality-order
+// METHOD: POST
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.placeRealityOrder(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/preSetLeverage.js
+++ b/examples/apidoc/RestClientV3/preSetLeverage.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/pre-set-leverage
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.preSetLeverage(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/setCollateralType.js
+++ b/examples/apidoc/RestClientV3/setCollateralType.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/set-collateral-type
+// METHOD: POST
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.setCollateralType(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/RestClientV3/setMargin.js
+++ b/examples/apidoc/RestClientV3/setMargin.js
@@ -1,0 +1,23 @@
+import { RestClientV3 } from 'bitget-api';
+// or, if require is preferred:
+// const { RestClientV3 } = require('bitget-api');
+
+// This example shows how to call this Bitget API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "bitget-api" for Bitget exchange
+// This Bitget API SDK is available on npm via "npm install bitget-api"
+// ENDPOINT: /api/v3/account/set-margin
+// METHOD: POST
+// PUBLIC: NO
+
+const client = new RestClientV3({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+  apiPass: 'insert_api_pass_here',
+});
+
+client.setMargin(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/llms.txt
+++ b/llms.txt
@@ -49,7 +49,7 @@ Notes:
 Directory Structure
 ================================================================
 examples/
-  Auth/
+  auth/
     fasterHmacSign.ts
     rest-private-rsa.md
     rest-private-rsa.ts
@@ -157,76 +157,7 @@ Files
 ================================================================
 
 ================
-File: examples/Auth/fasterHmacSign.ts
-================
-import { createHmac } from 'crypto';
-⋮----
-import {
-  DefaultLogger,
-  RestClientV3,
-  WebsocketClientV3,
-} from '../../src/index.js';
-⋮----
-// or
-// import { createHmac } from 'crypto';
-// import { DefaultLogger, RestClientV3, WebsocketClientV3 } from 'bitget-api';
-⋮----
-/**
- * Injecting a custom signMessage function.
- *
- * As of version 3.0.0 of the bitget-api Node.js/TypeScript/JavaScript
- * SDK for Bitget, the SDK uses the Web Crypto API for signing requests.
- * While it is compatible with Node and Browser environments, it is
- * slightly slower than using Node's native crypto module (only
- * available in backend Node environments).
- *
- * For latency sensitive users, you can inject the previous node crypto sign
- * method (or your own even faster implementation), if this change affects you.
- *
- * This example demonstrates how to inject a custom sign function, to achieve
- * the same peformance as seen before the Web Crypto API was introduced.
- *
- * For context on standard usage, the "signMessage" function is used:
- * - During every single API call
- * - After opening a new private WebSocket connection
- */
-⋮----
-/**
-   * Set this to true to enable demo trading:
-   */
-⋮----
-/**
-   * Overkill in almost every case, but if you need any optimisation available,
-   * you can inject a faster sign mechanism such as node's native createHmac:
-   */
-⋮----
-// Optional, uncomment the "trace" override to log a lot more info about what the WS client is doing
-⋮----
-// trace: (...params) => console.log('trace', ...params),
-⋮----
-/**
-     * Set this to true to enable demo trading for the private account data WS
-     * Topics: order,execution,position,wallet,greeks
-     */
-⋮----
-/**
-     * Overkill in almost every case, but if you need any optimisation available,
-     * you can inject a faster sign mechanism such as node's native createHmac:
-     */
-⋮----
-function setWsClientEventListeners(
-  websocketClient: WebsocketClientV3,
-  accountRef: string,
-): Promise<void>
-⋮----
-// console.log('raw message received ', JSON.stringify(data, null, 2));
-⋮----
-// Simple promise to ensure we're subscribed before trying anything else
-⋮----
-// Start trading
-
-================
-File: examples/Auth/rest-private-rsa.md
+File: examples/auth/rest-private-rsa.md
 ================
 # RSA Authentication with Bitget APIs in Node.js, JavaScript & TypeScript
 
@@ -337,29 +268,6 @@ const clientV3 = new RestClientV3({
 ```
 
 For a complete example, refer to the [rest-private-rsa.ts](./rest-private-rsa.ts) file on GitHub.
-
-================
-File: examples/Auth/rest-private-rsa.ts
-================
-import { RestClientV2, RestClientV3 } from '../../src/index.js';
-⋮----
-// Import frmo NPM:
-// import { RestClientV2, RestClientV3 } from 'bitget-api';
-// or if you prefer require:
-// const { RestClientV2, RestClientV3 } = require('bitget-api');
-⋮----
-// Received after creating a new API key with a self-generated RSA public key on Bitget
-⋮----
-// The self-generated RSA private key, this is never directly given to Bitget, but used to generate a signature
-// Note: this MUST include the "BEGIN PRIVATE KEY" header so that the SDK understands this is RSA auth
-⋮----
-// This is set by you when registering your RSA API key in Bitget's website.
-⋮----
-// const wsClient = new WebsocketClientV2({
-//   apiKey: API_KEY,
-//   apiSecret: rsaPrivateKey,
-//   apiPass: API_PASS,
-// });
 
 ================
 File: examples/README.md
@@ -2075,6 +1983,18 @@ export interface WSPositionSnapshotUMCBL extends WsBaseEvent<'snapshot'> {
   };
   data: WsPositionSnapshotDataUMCBL[];
 }
+⋮----
+/** Classic V2 depth channel push data. checksum removed May 2026 - use seq instead */
+export interface WsDepthBookDataV2 {
+  asks: [string, string][];
+  bids: [string, string][];
+  ts: string;
+  seq: string;
+  /** Futures books channel only - previous push serial number */
+  pseq?: string;
+}
+⋮----
+/** Futures books channel only - previous push serial number */
 
 ================
 File: src/websocket-client-v2.ts
@@ -2627,6 +2547,29 @@ File: tsconfig.linting.json
 }
 
 ================
+File: examples/auth/rest-private-rsa.ts
+================
+import { RestClientV2, RestClientV3 } from '../../src/index.js';
+⋮----
+// Import frmo NPM:
+// import { RestClientV2, RestClientV3 } from 'bitget-api';
+// or if you prefer require:
+// const { RestClientV2, RestClientV3 } = require('bitget-api');
+⋮----
+// Received after creating a new API key with a self-generated RSA public key on Bitget
+⋮----
+// The self-generated RSA private key, this is never directly given to Bitget, but used to generate a signature
+// Note: this MUST include the "BEGIN PRIVATE KEY" header so that the SDK understands this is RSA auth
+⋮----
+// This is set by you when registering your RSA API key in Bitget's website.
+⋮----
+// const wsClient = new WebsocketClientV2({
+//   apiKey: API_KEY,
+//   apiSecret: rsaPrivateKey,
+//   apiPass: API_PASS,
+// });
+
+================
 File: examples/V2 - Classic/Rest/rest-private-futures.ts
 ================
 import { RestClientV2 } from '../../../src/index.js';
@@ -2727,11 +2670,6 @@ import { RestClientV3 } from '../../../src/index.js';
 ⋮----
 // or
 // import { RestClientV3 } from 'bitget-api';
-
-================
-File: src/constants/enum.ts
-================
-/** Parameter verification exception margin mode == FIXED */
 
 ================
 File: src/types/request/v2/common.ts
@@ -3469,7 +3407,12 @@ export type StrategyTriggerByV3 = 'market' | 'mark';
 export type StrategyTriggerOrderTypeV3 = 'limit' | 'market';
 ⋮----
 export interface PlaceStrategyOrderRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
   symbol: string;
   clientOid?: string;
   type?: StrategyOrderTypeV3;
@@ -3519,12 +3462,22 @@ export interface CancelStrategyOrderRequestV3 {
 }
 ⋮----
 export interface GetUnfilledStrategyOrdersRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
   type?: StrategyOrderTypeV3;
 }
 ⋮----
 export interface GetHistoryStrategyOrdersRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
   type?: StrategyOrderTypeV3;
   startTime?: string;
   endTime?: string;
@@ -3651,6 +3604,36 @@ export interface ModifyOrderRequestV3 {
   qty?: string;
   price?: string;
   autoCancel?: 'yes' | 'no';
+  symbol?: string;
+  category?:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  tpTriggerBy?: 'market' | 'mark';
+  slTriggerBy?: 'market' | 'mark';
+  takeProfit?: string;
+  stopLoss?: string;
+  tpOrderType?: 'limit' | 'market';
+  slOrderType?: 'limit' | 'market';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+}
+⋮----
+export interface PlaceRealityOrderRequestV3 {
+  symbol: string;
+  side: 'buy' | 'sell';
+  orderType: 'limit' | 'market';
+  qty: string;
+  price?: string;
+  clientOid?: string;
+}
+⋮----
+export interface CancelRealityOrderRequestV3 {
+  symbol: string;
+  orderId?: string;
+  clientOid?: string;
 }
 ⋮----
 export interface PlaceBatchOrdersRequestV3 {
@@ -5710,6 +5693,75 @@ repomix.sh
 coverage
 
 ================
+File: examples/auth/fasterHmacSign.ts
+================
+import { createHmac } from 'crypto';
+⋮----
+import {
+  DefaultLogger,
+  RestClientV3,
+  WebsocketClientV3,
+} from '../../src/index.js';
+⋮----
+// or
+// import { createHmac } from 'crypto';
+// import { DefaultLogger, RestClientV3, WebsocketClientV3 } from 'bitget-api';
+⋮----
+/**
+ * Injecting a custom signMessage function.
+ *
+ * As of version 3.0.0 of the bitget-api Node.js/TypeScript/JavaScript
+ * SDK for Bitget, the SDK uses the Web Crypto API for signing requests.
+ * While it is compatible with Node and Browser environments, it is
+ * slightly slower than using Node's native crypto module (only
+ * available in backend Node environments).
+ *
+ * For latency sensitive users, you can inject the previous node crypto sign
+ * method (or your own even faster implementation), if this change affects you.
+ *
+ * This example demonstrates how to inject a custom sign function, to achieve
+ * the same peformance as seen before the Web Crypto API was introduced.
+ *
+ * For context on standard usage, the "signMessage" function is used:
+ * - During every single API call
+ * - After opening a new private WebSocket connection
+ */
+⋮----
+/**
+   * Set this to true to enable demo trading:
+   */
+⋮----
+/**
+   * Overkill in almost every case, but if you need any optimisation available,
+   * you can inject a faster sign mechanism such as node's native createHmac:
+   */
+⋮----
+// Optional, uncomment the "trace" override to log a lot more info about what the WS client is doing
+⋮----
+// trace: (...params) => console.log('trace', ...params),
+⋮----
+/**
+     * Set this to true to enable demo trading for the private account data WS
+     * Topics: order,execution,position,wallet,greeks
+     */
+⋮----
+/**
+     * Overkill in almost every case, but if you need any optimisation available,
+     * you can inject a faster sign mechanism such as node's native createHmac:
+     */
+⋮----
+function setWsClientEventListeners(
+  websocketClient: WebsocketClientV3,
+  accountRef: string,
+): Promise<void>
+⋮----
+// console.log('raw message received ', JSON.stringify(data, null, 2));
+⋮----
+// Simple promise to ensure we're subscribed before trying anything else
+⋮----
+// Start trading
+
+================
 File: examples/V2 - Classic/Rest/rest-trade-futures.ts
 ================
 import {
@@ -6239,6 +6291,11 @@ import {
         "ts": "1751980011084"
       }
      */
+
+================
+File: src/constants/enum.ts
+================
+/** Parameter verification exception margin mode == FIXED */
 
 ================
 File: src/types/request/v3/broker.ts
@@ -6812,6 +6869,7 @@ export interface OrderInfoV3 {
   orderStatus: string;
   posSide: string;
   holdMode: string;
+  delegateType?: string;
   reduceOnly: string;
   feeDetail: FeeDetailV3[];
   cancelReason: string;
@@ -6950,6 +7008,19 @@ export interface CurrentPositionV3 {
   closeFeeTotal: string;
   createdTime: string;
   updatedTime: string;
+}
+⋮----
+export interface LoanDataDebtCoinV3 {
+  coin: string;
+  debt: string;
+  interestFreeAmount: string;
+  interestRateNextHour: string;
+}
+⋮----
+export interface LoanDataV3 {
+  currentLoans: string;
+  interestPaymentTime: string;
+  debtCoinList: LoanDataDebtCoinV3[];
 }
 ⋮----
 export interface ModifyOrderResponseV3 {
@@ -8404,7 +8475,15 @@ export interface GetContractsOiRequestV3 {
 }
 ⋮----
 export interface GetCurrentFundingRateRequestV3 {
-  symbol: string;
+  category?: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+}
+⋮----
+export interface GetLiquidationsRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  limit?: string;
+  cursor?: string;
 }
 ⋮----
 export interface GetHistoryFundingRateRequestV3 {
@@ -8451,7 +8530,7 @@ export interface GetInstrumentsRequestV3 {
 ⋮----
 export interface GetMarketFeeGroupRequestV3 {
   category: 'SPOT' | 'FUTURES';
-  group?: 'GROUP_A' | 'GROUP_B' | 'GROUP_C';
+  group?: 'DEFAULT' | 'GROUP_A' | 'GROUP_B' | 'GROUP_C';
 }
 ⋮----
 export interface GetMarketScoreWeightsRequestV3 {
@@ -8471,6 +8550,54 @@ export interface GetTickersRequestV3 {
 ⋮----
 export interface GetIndexComponentsRequestV3 {
   symbol: string;
+}
+⋮----
+export interface GetRpiOrderBookRequestV3 {
+  category: 'SPOT' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  limit?: string;
+}
+⋮----
+export interface GetCashDividendRecordsRequestV3 {
+  symbol: string;
+  type: 'pending' | 'paid';
+  cursor?: string;
+  limit?: string;
+}
+⋮----
+export interface GetSpotWhaleFlowRequestV3 {
+  symbol: string;
+}
+⋮----
+export interface GetSpotFundFlowRequestV3 {
+  symbol: string;
+  period?: string;
+}
+⋮----
+export interface GetSpotNetFlowRequestV3 {
+  symbol: string;
+}
+⋮----
+export interface GetMarginLongShortRequestV3 {
+  symbol: string;
+  period?: '24h' | '30d';
+  coin?: string;
+}
+⋮----
+export interface GetMarginLoanGrowthRequestV3 {
+  symbol: string;
+  period?: string;
+  coin?: string;
+}
+⋮----
+export interface GetMarginIsolatedBorrowRequestV3 {
+  symbol: string;
+  period?: string;
+}
+⋮----
+export interface GetFuturesTradingDataRequestV3 {
+  symbol: string;
+  period?: string;
 }
 
 ================
@@ -9535,6 +9662,8 @@ export interface FuturesIsolatedSymbolV2 {
 File: src/types/response/v3/account.ts
 ================
 // Account Management Response Types
+import type { CollateralTypeV3 } from '../../request/v3/account.js';
+⋮----
 export interface AccountSymbolConfigV3 {
   category: string;
   symbol: string;
@@ -9603,7 +9732,15 @@ export interface AccountAssetV3 {
   available: string;
   debt: string;
   locked: string;
+  /** Position value in USD */
+  positionValue?: string;
+  /** Account leverage (non-negative) */
+  leverage?: string;
 }
+⋮----
+/** Position value in USD */
+⋮----
+/** Account leverage (non-negative) */
 ⋮----
 export interface AccountAssetsV3 {
   accountEquity: string;
@@ -9639,7 +9776,13 @@ export interface FinancialRecordV3 {
   fee: string;
   balance: string;
   ts: string;
+  /** crossed | isolated */
+  positionType?: string;
+  positionAmount?: string;
+  positionBalance?: string;
 }
+⋮----
+/** crossed | isolated */
 ⋮----
 export interface PaymentCoinV3 {
   coin: string;
@@ -9724,8 +9867,15 @@ export interface WithdrawAddressBookV3 {
 ⋮----
 // Transfer Response Types
 ⋮----
+export interface AllSymbolFeeRateV3 {
+  symbol: string;
+  makerFeeRate: string;
+  takerFeeRate: string;
+}
+⋮----
 export interface TransferResponseV3 {
   transferId: string;
+  clientOid?: string;
 }
 ⋮----
 export interface SubTransferRecordV3 {
@@ -9844,592 +9994,32 @@ export interface TaxRecordV3 {
   balance: string;
   ts: string;
 }
-
-================
-File: src/types/request/v3/account.ts
-================
-// Account Management Request Types
 ⋮----
-export type AccountAdjustModeV3 = 'basic' | 'advanced' | 'delta' | 'isolated';
-⋮----
-export interface AdjustAccountModeRequestV3 {
-  mode: AccountAdjustModeV3;
-  /** Sub-account UID when the master account switches mode for a sub-account */
-  targetUid?: string;
+export interface CollateralTypeConfigV3 {
+  collateralType: CollateralTypeV3;
+  /** Returned when collateralType=custom */
+  collateralCoins?: string;
 }
 ⋮----
-/** Sub-account UID when the master account switches mode for a sub-account */
+/** Returned when collateralType=custom */
 ⋮----
-export interface SetLeverageRequestV3 {
-  category: 'MARGIN' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol?: string;
-  leverage: string;
-  coin?: string;
-  posSide?: 'long' | 'short';
+export interface CustomCollateralCoinV3 {
+  collateralCoin: string;
 }
 ⋮----
-export interface GetConvertRecordsRequestV3 {
-  fromCoin: string;
-  toCoin: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  cursor?: string;
+export interface PreSetLeverageV3 {
+  estMaxOpen?: string;
+  estMaxBorrowable?: string;
+  requiredMargin: string;
+  marginChange: string;
 }
 ⋮----
-export interface GetFinancialRecordsRequestV3 {
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  coin?: string;
-  type?: string;
-  startTime?: string;
-  endTime?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface RepayRequestV3 {
-  repayableCoinList: string[];
-  paymentCoinList: string[];
-}
-⋮----
-// Sub-account Management Request Types
-⋮----
-export interface CreateSubAccountApiKeyRequestV3 {
-  subUid: string;
-  note: string;
-  type: 'read_write' | 'read_only';
-  passphrase: string;
-  permissions: string[];
-  ips: string[];
-}
-⋮----
-export interface DeleteSubAccountApiKeyRequestV3 {
-  apiKey: string;
-}
-⋮----
-export interface GetSubAccountApiKeysRequestV3 {
-  subUid: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface UpdateSubAccountApiKeyRequestV3 {
-  apiKey: string;
-  passphrase: string;
-  type?: 'read_write' | 'read_only';
-  permissions?: string[];
-  ips?: string[];
-}
-⋮----
-export interface CreateSubAccountRequestV3 {
-  username: string;
-  accountMode?: 'classic' | 'unified';
-  note?: string;
-}
-⋮----
-export interface FreezeSubAccountRequestV3 {
-  subUid: string;
-  operation: 'freeze' | 'unfreeze';
-}
-⋮----
-export interface GetSubAccountListRequestV3 {
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-// Transfer Request Types
-⋮----
-export interface TransferRequestV3 {
-  fromType:
-    | 'spot'
-    | 'p2p'
-    | 'coin-futures'
-    | 'usdt-futures'
-    | 'usdc-futures'
-    | 'crossed-margin'
-    | 'isolated-margin'
-    | 'uta';
-  toType:
-    | 'spot'
-    | 'p2p'
-    | 'coin-futures'
-    | 'usdt-futures'
-    | 'usdc-futures'
-    | 'crossed-margin'
-    | 'isolated-margin'
-    | 'uta';
-  amount: string;
+export interface MaxWithdrawalV3 {
   coin: string;
-  symbol?: string;
-  /** Enable automatic margin borrowing when balance insufficient. yes | no */
-  allowBorrow?: 'yes' | 'no';
-}
-⋮----
-/** Enable automatic margin borrowing when balance insufficient. yes | no */
-⋮----
-export interface GetTransferableCoinsRequestV3 {
-  fromType:
-    | 'spot'
-    | 'p2p'
-    | 'coin-futures'
-    | 'usdt-futures'
-    | 'usdc-futures'
-    | 'crossed-margin'
-    | 'isolated-margin'
-    | 'uta';
-  toType:
-    | 'spot'
-    | 'p2p'
-    | 'coin-futures'
-    | 'usdt-futures'
-    | 'usdc-futures'
-    | 'crossed-margin'
-    | 'isolated-margin'
-    | 'uta';
-}
-⋮----
-export interface GetSubTransferRecordsRequestV3 {
-  subUid?: string;
-  role?: 'initiator' | 'receiver';
-  coin?: string;
-  startTime?: string;
-  endTime?: string;
-  clientOid?: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface SubAccountTransferRequestV3 {
-  fromType:
-    | 'spot'
-    | 'p2p'
-    | 'usdt_futures'
-    | 'coin_futures'
-    | 'usdc_futures'
-    | 'crossed_margin'
-    | 'uta';
-  toType:
-    | 'spot'
-    | 'p2p'
-    | 'usdt_futures'
-    | 'coin_futures'
-    | 'usdc_futures'
-    | 'crossed_margin'
-    | 'uta';
-  amount: string;
-  coin: string;
-  fromUserId: string;
-  toUserId: string;
-  clientOid: string;
-  /** Enable automatic margin borrowing when balance insufficient. yes | no */
-  allowBorrow?: 'yes' | 'no';
-}
-⋮----
-/** Enable automatic margin borrowing when balance insufficient. yes | no */
-⋮----
-export interface GetSubUnifiedAssetsRequestV3 {
-  subUid?: string;
-  cursor?: string;
-  limit?: string;
-}
-⋮----
-export interface GetFeeRateRequestV3 {
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  symbol: string;
-}
-⋮----
-export interface GetFundingAssetsRequestV3 {
-  coin?: string;
-}
-⋮----
-export interface SwitchDeductRequestV3 {
-  deduct: 'on' | 'off';
-}
-⋮----
-// Deposit Request Types
-⋮----
-export interface GetDepositAddressRequestV3 {
-  coin: string;
-  chain?: string;
-  size?: string;
-}
-⋮----
-export interface GetSubDepositAddressRequestV3 {
-  subUid: string;
-  coin: string;
-  chain?: string;
-  size?: string;
-}
-⋮----
-export interface GetDepositRecordsRequestV3 {
-  coin?: string;
-  orderId?: string;
-  startTime: string;
-  endTime: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetSubDepositRecordsRequestV3 {
-  coin?: string;
-  subUid: string;
-  startTime: string;
-  endTime: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-// Withdraw Request Types
-⋮----
-export interface WithdrawRequestV3 {
-  coin: string;
-  chain?: string;
-  transferType: 'on_chain' | 'internal_transfer';
-  address: string;
-  innerToType?: 'uid' | 'email' | 'mobile';
-  areaCode?: string;
-  tag?: string;
-  size: string;
-  remark?: string;
-  clientOid?: string;
-  memberCode?: 'bithumb' | 'korbit' | 'coinone';
-  identityType?: 'company' | 'user';
-  companyName?: string;
-  firstName?: string;
-  lastName?: string;
-}
-⋮----
-export interface GetWithdrawRecordsRequestV3 {
-  coin?: string;
-  orderId?: string;
-  clientOid?: string;
-  startTime: string;
-  endTime: string;
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface GetWithdrawAddressBookRequestV3 {
-  coin?: string;
-  type?: 'EVM' | 'regular' | 'universal' | 'internal';
-  limit?: string;
-  cursor?: string;
-}
-⋮----
-export interface CancelWithdrawalRequestV3 {
-  orderId?: string;
-  clientOid?: string;
-}
-⋮----
-export interface SetDepositAccountRequestV3 {
-  coin: string;
-  accountType: 'funding' | 'unified' | 'otc';
-}
-⋮----
-export interface GetMaxTransferableRequestV3 {
-  coin: string;
-}
-⋮----
-export interface GetOpenInterestLimitRequestV3 {
-  symbol: string;
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-}
-⋮----
-export interface GetTaxRecordsRequestV3 {
-  bizType:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES'
-    | 'OTHER';
-  marginType?: 'isolated' | 'crossed';
-  coin?: string;
-  startTime: string;
-  endTime: string;
-  limit?: string;
-  cursor?: string;
-}
-
-================
-File: src/types/response/v3/public.ts
-================
-export interface PublicFillV3 {
-  execId: string;
-  price: string;
-  size: string;
-  side: 'sell' | 'buy';
-  ts: string;
-}
-⋮----
-export interface CandlestickV3 extends Array<string> {
-  0: string; // timestamp
-  1: string; // open price
-  2: string; // high price
-  3: string; // low price
-  4: string; // close price
-  5: string; // volume
-  6: string; // turnover
-}
-⋮----
-0: string; // timestamp
-1: string; // open price
-2: string; // high price
-3: string; // low price
-4: string; // close price
-5: string; // volume
-6: string; // turnover
-⋮----
-export interface ContractOiV3 {
-  symbol: string;
-  notionalValue: string;
-  totalNotionalValue: string;
-}
-⋮----
-export interface CurrentFundingRateV3 {
-  symbol: string;
-  fundingRate: string;
-  fundingRateInterval: string;
-  nextUpdate: string;
-  minFundingRate: string;
-  maxFundingRate: string;
-}
-⋮----
-export interface DiscountRateTierV3 {
-  tierStartValue: string;
-  discountRate: string;
-}
-⋮----
-export interface DiscountRateV3 {
-  coin: string;
-  list: DiscountRateTierV3[];
-}
-⋮----
-export interface HistoryFundingRateV3 {
-  symbol: string;
-  fundingRate: string;
-  fundingRateTimestamp: string;
-}
-⋮----
-export interface MarginLoanV3 {
-  dailyInterest: string;
-  annualInterest: string;
-  limit: string;
-}
-⋮----
-export interface OpenInterestItemV3 {
-  symbol: string;
-  openInterest: string;
-}
-⋮----
-export interface OpenInterestV3 {
-  list: OpenInterestItemV3[];
-  ts: string;
-}
-⋮----
-export interface PositionTierV3 {
-  tier: string;
-  minTierValue: string;
-  maxTierValue: string;
-  leverage: string;
-  mmr: string;
-}
-⋮----
-export interface RiskReserveRecordV3 {
-  balance: string;
-  amount: string;
-  ts: string;
-  type?: string;
-}
-⋮----
-export interface RiskReserveV3 {
-  totalBalance?: string;
-  coin: string;
-  riskReserveRecords: RiskReserveRecordV3[];
-}
-⋮----
-export interface RiskReserveHourRecordV3 {
-  amount: string;
-  balance: string;
-  ts: string;
-}
-⋮----
-export interface RiskReserveHourV3 {
-  coin: string;
-  riskReserveRecords: RiskReserveHourRecordV3[];
-}
-⋮----
-export interface RiskReserveAllItemV3 {
-  symbols: string[];
-  coin: string;
-  balance: string;
-}
-⋮----
-export interface RiskReserveAllV3 {
-  list: RiskReserveAllItemV3[];
-}
-⋮----
-export interface InstrumentV3 {
-  symbol: string;
-  category:
-    | 'SPOT'
-    | 'MARGIN'
-    | 'USDT-FUTURES'
-    | 'COIN-FUTURES'
-    | 'USDC-FUTURES';
-  baseCoin: string;
-  quoteCoin: string;
-  buyLimitPriceRatio: string;
-  sellLimitPriceRatio: string;
-  feeRateUpRatio: string;
-  minOrderQty: string;
-  maxOrderQty: string;
-  maxMarketOrderQty: string;
-  pricePrecision: string;
-  quantityPrecision: string;
-  quotePrecision: string;
-  minOrderAmount: string;
-  maxSymbolOrderNum: string;
-  maxProductOrderNum: string;
-  status:
-    | 'listed'
-    | 'online'
-    | 'limit_open'
-    | 'limit_close'
-    | 'offline'
-    | 'restrictedAPI';
-  offTime: string;
-  limitOpenTime: string;
-  maintainTime: string;
-  areaSymbol?: string;
-
-  // Futures specific fields
-  makerFeeRate?: string;
-  takerFeeRate?: string;
-  openCostUpRatio?: string;
-  priceMultiplier?: string;
-  quantityMultiplier?: string;
-  symbolType?: 'perpetual' | 'delivery';
-  maxPositionNum?: string;
-  deliveryTime?: string;
-  deliveryStartTime?: string;
-  deliveryPeriod?: string;
-  /** Launch time - Unix millisecond timestamp. Null for some margin pairs. */
-  launchTime?: string | null;
-  fundInterval?: string;
-  minLeverage?: string;
-  maxLeverage?: string;
-
-  // Margin specific fields
-  isIsolatedBaseBorrowable?: 'YES' | 'NO';
-  isIsolatedQuotedBorrowable?: 'YES' | 'NO';
-  warningRiskRatio?: string;
-  liquidationRiskRatio?: string;
-  maxCrossedLeverage?: string;
-  maxIsolatedLeverage?: string;
-  userMinBorrow?: string;
-}
-⋮----
-// Futures specific fields
-⋮----
-/** Launch time - Unix millisecond timestamp. Null for some margin pairs. */
-⋮----
-// Margin specific fields
-⋮----
-export interface MarketFeeGroupLabelV3 {
-  weight: string;
-  label: string;
-  symbols: string[];
-}
-⋮----
-export interface MarketFeeGroupTierV3 {
-  level: string;
-  makerFeeRate: string;
-}
-⋮----
-export interface MarketFeeGroupV3 {
-  category: string;
-  group: string;
-  labelList: MarketFeeGroupLabelV3[];
-  tierList: MarketFeeGroupTierV3[];
-}
-⋮----
-export interface MarketScoreWeightV3 {
-  category: string;
-  label: string;
-  symbol: string;
-  requiredSpread: string;
-  minMakerVolume: string;
-  weight: string;
-}
-⋮----
-export interface OrderBookV3 {
-  a: string[][]; // asks - [price, size]
-  b: string[][]; // bids - [price, size]
-  ts: string;
-}
-⋮----
-a: string[][]; // asks - [price, size]
-b: string[][]; // bids - [price, size]
-⋮----
-export interface TickerV3 {
-  category: 'SPOT' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
-  symbol: string;
-  lastPrice: string;
-  openPrice24h: string;
-  highPrice24h: string;
-  lowPrice24h: string;
-  ask1Price: string;
-  bid1Price: string;
-  bid1Size: string;
-  ask1Size: string;
-  price24hPcnt: string;
-  volume24h: string;
-  turnover24h: string;
-
-  // Futures specific fields
-  indexPrice?: string;
-  markPrice?: string;
-  fundingRate?: string;
-  openInterest?: string;
-  deliveryStartTime?: string;
-  deliveryTime?: string;
-  deliveryStatus?: string;
-}
-⋮----
-// Futures specific fields
-⋮----
-export interface ProofOfReservesV3 {
-  merkleRootHash: string;
-  totalReserveRatio: string;
-  list: {
-    coin: string;
-    userAssets: string;
-    platformAssets: string;
-    reserveRatio: string;
-  }[];
-}
-⋮----
-export interface IndexComponentV3 {
-  exchange: string;
-  spotPair: string;
-  equivalentPrice: string;
-  weight: string;
-}
-⋮----
-export interface IndexPriceComponentsV3 {
-  symbol: string;
-  componentList: IndexComponentV3[];
+  otcMaxWithdrawal: string;
+  spotMaxWithdrawal: string;
+  utaMaxWithdrawal: string;
+  totalMaxWithdrawal: string;
 }
 
 ================
@@ -10707,6 +10297,762 @@ export interface WebsocketClientOptions extends WSClientConfigurableOptions {
 }
 
 ================
+File: src/types/request/v3/account.ts
+================
+// Account Management Request Types
+⋮----
+export type AccountAdjustModeV3 = 'basic' | 'advanced' | 'delta' | 'isolated';
+⋮----
+export interface AdjustAccountModeRequestV3 {
+  mode: AccountAdjustModeV3;
+  /** Sub-account UID when the master account switches mode for a sub-account */
+  targetUid?: string;
+}
+⋮----
+/** Sub-account UID when the master account switches mode for a sub-account */
+⋮----
+export interface SetLeverageRequestV3 {
+  category: 'MARGIN' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  leverage: string;
+  coin?: string;
+  posSide?: 'long' | 'short';
+  /** Futures only. Defaults to crossed */
+  marginMode?: 'crossed' | 'isolated';
+  /** Isolated two-way mode: long leverage. Takes priority over leverage when both set */
+  longLeverage?: string;
+  /** Isolated two-way mode: short leverage. Takes priority over leverage when both set */
+  shortLeverage?: string;
+}
+⋮----
+/** Futures only. Defaults to crossed */
+⋮----
+/** Isolated two-way mode: long leverage. Takes priority over leverage when both set */
+⋮----
+/** Isolated two-way mode: short leverage. Takes priority over leverage when both set */
+⋮----
+export interface GetAllFeeRatesRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol?: string;
+}
+⋮----
+export interface GetConvertRecordsRequestV3 {
+  fromCoin?: string;
+  toCoin?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetFinancialRecordsRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  coin?: string;
+  type?: string;
+  startTime?: string;
+  endTime?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface RepayRequestV3 {
+  repayableCoinList: string[];
+  paymentCoinList: string[];
+}
+⋮----
+// Sub-account Management Request Types
+⋮----
+export interface CreateSubAccountApiKeyRequestV3 {
+  subUid: string;
+  note: string;
+  type: 'read_write' | 'read_only';
+  passphrase: string;
+  permissions: string[];
+  ips: string[];
+}
+⋮----
+export interface DeleteSubAccountApiKeyRequestV3 {
+  apiKey: string;
+}
+⋮----
+export interface GetSubAccountApiKeysRequestV3 {
+  subUid: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface UpdateSubAccountApiKeyRequestV3 {
+  apiKey: string;
+  passphrase: string;
+  type?: 'read_write' | 'read_only';
+  permissions?: string[];
+  ips?: string[];
+}
+⋮----
+export interface CreateSubAccountRequestV3 {
+  username: string;
+  accountMode?: 'classic' | 'unified';
+  note?: string;
+}
+⋮----
+export interface FreezeSubAccountRequestV3 {
+  subUid: string;
+  operation: 'freeze' | 'unfreeze';
+}
+⋮----
+export interface GetSubAccountListRequestV3 {
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+// Transfer Request Types
+⋮----
+export interface TransferRequestV3 {
+  clientOid?: string;
+  fromType:
+    | 'spot'
+    | 'p2p'
+    | 'coin-futures'
+    | 'usdt-futures'
+    | 'usdc-futures'
+    | 'crossed-margin'
+    | 'isolated-margin'
+    | 'uta';
+  toType:
+    | 'spot'
+    | 'p2p'
+    | 'coin-futures'
+    | 'usdt-futures'
+    | 'usdc-futures'
+    | 'crossed-margin'
+    | 'isolated-margin'
+    | 'uta';
+  amount: string;
+  coin: string;
+  symbol?: string;
+  /** Enable automatic margin borrowing when balance insufficient. yes | no */
+  allowBorrow?: 'yes' | 'no';
+}
+⋮----
+/** Enable automatic margin borrowing when balance insufficient. yes | no */
+⋮----
+export interface GetTransferableCoinsRequestV3 {
+  fromType:
+    | 'spot'
+    | 'p2p'
+    | 'coin-futures'
+    | 'usdt-futures'
+    | 'usdc-futures'
+    | 'crossed-margin'
+    | 'isolated-margin'
+    | 'uta';
+  toType:
+    | 'spot'
+    | 'p2p'
+    | 'coin-futures'
+    | 'usdt-futures'
+    | 'usdc-futures'
+    | 'crossed-margin'
+    | 'isolated-margin'
+    | 'uta';
+}
+⋮----
+export interface GetSubTransferRecordsRequestV3 {
+  subUid?: string;
+  role?: 'initiator' | 'receiver';
+  coin?: string;
+  startTime?: string;
+  endTime?: string;
+  clientOid?: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface SubAccountTransferRequestV3 {
+  fromType:
+    | 'spot'
+    | 'p2p'
+    | 'usdt_futures'
+    | 'coin_futures'
+    | 'usdc_futures'
+    | 'crossed_margin'
+    | 'uta';
+  toType:
+    | 'spot'
+    | 'p2p'
+    | 'usdt_futures'
+    | 'coin_futures'
+    | 'usdc_futures'
+    | 'crossed_margin'
+    | 'uta';
+  amount: string;
+  coin: string;
+  fromUserId: string;
+  toUserId: string;
+  clientOid: string;
+  /** Enable automatic margin borrowing when balance insufficient. yes | no */
+  allowBorrow?: 'yes' | 'no';
+}
+⋮----
+/** Enable automatic margin borrowing when balance insufficient. yes | no */
+⋮----
+export interface GetSubUnifiedAssetsRequestV3 {
+  subUid?: string;
+  cursor?: string;
+  limit?: string;
+}
+⋮----
+export interface GetFeeRateRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol: string;
+}
+⋮----
+export interface GetFundingAssetsRequestV3 {
+  coin?: string;
+}
+⋮----
+export interface SwitchDeductRequestV3 {
+  deduct: 'on' | 'off';
+}
+⋮----
+// Deposit Request Types
+⋮----
+export interface GetDepositAddressRequestV3 {
+  coin: string;
+  chain?: string;
+  size?: string;
+}
+⋮----
+export interface GetSubDepositAddressRequestV3 {
+  subUid: string;
+  coin: string;
+  chain?: string;
+  size?: string;
+}
+⋮----
+export interface GetDepositRecordsRequestV3 {
+  coin?: string;
+  orderId?: string;
+  startTime: string;
+  endTime: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetSubDepositRecordsRequestV3 {
+  coin?: string;
+  subUid: string;
+  startTime: string;
+  endTime: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+// Withdraw Request Types
+⋮----
+export interface WithdrawRequestV3 {
+  coin: string;
+  chain?: string;
+  /** Deduct from funding, uta, and/or otc accounts (comma-separated). Order: funding -> otc -> uta */
+  accountType?: string;
+  transferType: 'on_chain' | 'internal_transfer';
+  address: string;
+  innerToType?: 'uid' | 'email' | 'mobile';
+  areaCode?: string;
+  tag?: string;
+  size: string;
+  remark?: string;
+  clientOid?: string;
+  memberCode?: 'bithumb' | 'korbit' | 'coinone';
+  identityType?: 'company' | 'user';
+  companyName?: string;
+  firstName?: string;
+  lastName?: string;
+}
+⋮----
+/** Deduct from funding, uta, and/or otc accounts (comma-separated). Order: funding -> otc -> uta */
+⋮----
+export interface GetWithdrawRecordsRequestV3 {
+  coin?: string;
+  orderId?: string;
+  clientOid?: string;
+  startTime: string;
+  endTime: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface GetWithdrawAddressBookRequestV3 {
+  coin?: string;
+  type?: 'EVM' | 'regular' | 'universal' | 'internal';
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export interface CancelWithdrawalRequestV3 {
+  orderId?: string;
+  clientOid?: string;
+}
+⋮----
+export interface SetDepositAccountRequestV3 {
+  coin: string;
+  accountType: 'funding' | 'unified' | 'otc';
+}
+⋮----
+export interface GetMaxTransferableRequestV3 {
+  coin: string;
+}
+⋮----
+export interface GetOpenInterestLimitRequestV3 {
+  symbol: string;
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+}
+⋮----
+export interface GetTaxRecordsRequestV3 {
+  bizType:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES'
+    | 'OTHER';
+  marginType?: 'isolated' | 'crossed';
+  coin?: string;
+  startTime: string;
+  endTime: string;
+  limit?: string;
+  cursor?: string;
+}
+⋮----
+export type CollateralTypeV3 = 'mainstream' | 'all' | 'custom';
+⋮----
+export interface SetCollateralTypeRequestV3 {
+  collateralType: CollateralTypeV3;
+  /** Required when collateralType=custom. Comma-separated coin names */
+  collateralCoins?: string;
+}
+⋮----
+/** Required when collateralType=custom. Comma-separated coin names */
+⋮----
+export interface PreSetLeverageRequestV3 {
+  category: 'MARGIN' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  coin?: string;
+  marginMode: 'isolated' | 'cross';
+  leverage?: string;
+  longLeverage?: string;
+  shortLeverage?: string;
+}
+⋮----
+export interface SetMarginRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  posSide: 'long' | 'short';
+  operation: 'add' | 'remove';
+  amount: string;
+}
+⋮----
+export interface GetMaxWithdrawalRequestV3 {
+  coin: string;
+}
+
+================
+File: src/types/response/v3/public.ts
+================
+export interface PublicFillV3 {
+  execId: string;
+  price: string;
+  size: string;
+  side: 'sell' | 'buy';
+  ts: string;
+}
+⋮----
+export interface CandlestickV3 extends Array<string> {
+  0: string; // timestamp
+  1: string; // open price
+  2: string; // high price
+  3: string; // low price
+  4: string; // close price
+  5: string; // volume
+  6: string; // turnover
+}
+⋮----
+0: string; // timestamp
+1: string; // open price
+2: string; // high price
+3: string; // low price
+4: string; // close price
+5: string; // volume
+6: string; // turnover
+⋮----
+export interface ContractOiV3 {
+  symbol: string;
+  notionalValue: string;
+  totalNotionalValue: string;
+}
+⋮----
+export interface CurrentFundingRateV3 {
+  symbol: string;
+  fundingRate: string;
+  fundingRateInterval: string;
+  nextUpdate: string;
+  minFundingRate: string;
+  maxFundingRate: string;
+  cashDividend?: string;
+  cashDividendNextUpdate?: string;
+}
+⋮----
+export interface DiscountRateTierV3 {
+  tierStartValue: string;
+  discountRate: string;
+}
+⋮----
+export interface DiscountRateV3 {
+  coin: string;
+  list: DiscountRateTierV3[];
+}
+⋮----
+export interface HistoryFundingRateV3 {
+  symbol: string;
+  fundingRate: string;
+  fundingRateTimestamp: string;
+}
+⋮----
+export interface MarginLoanV3 {
+  dailyInterest: string;
+  annualInterest: string;
+  limit: string;
+}
+⋮----
+export interface OpenInterestItemV3 {
+  symbol: string;
+  openInterest: string;
+}
+⋮----
+export interface OpenInterestV3 {
+  list: OpenInterestItemV3[];
+  ts: string;
+}
+⋮----
+export interface PositionTierV3 {
+  tier: string;
+  minTierValue: string;
+  maxTierValue: string;
+  leverage: string;
+  mmr: string;
+}
+⋮----
+export interface RiskReserveRecordV3 {
+  balance: string;
+  amount: string;
+  ts: string;
+  type?: string;
+}
+⋮----
+export interface RiskReserveV3 {
+  totalBalance?: string;
+  coin: string;
+  riskReserveRecords: RiskReserveRecordV3[];
+}
+⋮----
+export interface RiskReserveHourRecordV3 {
+  amount: string;
+  balance: string;
+  ts: string;
+}
+⋮----
+export interface RiskReserveHourV3 {
+  coin: string;
+  riskReserveRecords: RiskReserveHourRecordV3[];
+}
+⋮----
+export interface RiskReserveAllItemV3 {
+  symbols: string[];
+  coin: string;
+  balance: string;
+}
+⋮----
+export interface RiskReserveAllV3 {
+  list: RiskReserveAllItemV3[];
+}
+⋮----
+export interface InstrumentV3 {
+  symbol: string;
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  baseCoin: string;
+  quoteCoin: string;
+  buyLimitPriceRatio: string;
+  sellLimitPriceRatio: string;
+  feeRateUpRatio: string;
+  minOrderQty: string;
+  maxOrderQty: string;
+  maxMarketOrderQty: string;
+  pricePrecision: string;
+  quantityPrecision: string;
+  quotePrecision: string;
+  minOrderAmount: string;
+  maxSymbolOrderNum: string;
+  maxProductOrderNum: string;
+  status:
+    | 'listed'
+    | 'online'
+    | 'limit_open'
+    | 'limit_close'
+    | 'offline'
+    | 'restrictedAPI';
+  offTime: string;
+  limitOpenTime: string;
+  maintainTime: string;
+  areaSymbol?: string;
+
+  /** yes = Reality stock token, no = non-Reality stock token */
+  isReality?: 'yes' | 'no';
+
+  // Futures specific fields
+  makerFeeRate?: string;
+  takerFeeRate?: string;
+  openCostUpRatio?: string;
+  priceMultiplier?: string;
+  quantityMultiplier?: string;
+  symbolType?: 'perpetual' | 'delivery';
+  maxPositionNum?: string;
+  deliveryTime?: string;
+  deliveryStartTime?: string;
+  deliveryPeriod?: string;
+  /** Launch time - Unix millisecond timestamp. Null for some margin pairs. */
+  launchTime?: string | null;
+  fundInterval?: string;
+  minLeverage?: string;
+  maxLeverage?: string;
+
+  // Margin specific fields
+  isIsolatedBaseBorrowable?: 'YES' | 'NO';
+  isIsolatedQuotedBorrowable?: 'YES' | 'NO';
+  warningRiskRatio?: string;
+  liquidationRiskRatio?: string;
+  maxCrossedLeverage?: string;
+  maxIsolatedLeverage?: string;
+  userMinBorrow?: string;
+}
+⋮----
+/** yes = Reality stock token, no = non-Reality stock token */
+⋮----
+// Futures specific fields
+⋮----
+/** Launch time - Unix millisecond timestamp. Null for some margin pairs. */
+⋮----
+// Margin specific fields
+⋮----
+export interface MarketFeeGroupLabelV3 {
+  weight: string;
+  label: string;
+  symbols: string[];
+}
+⋮----
+export interface MarketFeeGroupTierV3 {
+  level: string;
+  makerFeeRate: string;
+  /** PRO1~PRO6 only. Taker fee rate in decimal form */
+  takerFeeRate?: string;
+}
+⋮----
+/** PRO1~PRO6 only. Taker fee rate in decimal form */
+⋮----
+export interface MarketFeeGroupV3 {
+  category: string;
+  group: string;
+  labelList: MarketFeeGroupLabelV3[];
+  tierList: MarketFeeGroupTierV3[];
+}
+⋮----
+export interface MarketScoreWeightV3 {
+  category: string;
+  label: string;
+  symbol: string;
+  requiredSpread: string;
+  minMakerVolume: string;
+  weight: string;
+}
+⋮----
+export interface LiquidationV3 {
+  symbol: string;
+  side: 'buy' | 'sell';
+  price: string;
+  amount: string;
+  ts: string;
+}
+⋮----
+export interface LiquidationsV3 {
+  list: LiquidationV3[];
+  cursor?: string;
+}
+⋮----
+export interface OrderBookV3 {
+  a: string[][]; // asks - [price, size]
+  b: string[][]; // bids - [price, size]
+  ts: string;
+}
+⋮----
+a: string[][]; // asks - [price, size]
+b: string[][]; // bids - [price, size]
+⋮----
+export interface TickerV3 {
+  category: 'SPOT' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  lastPrice: string;
+  openPrice24h: string;
+  highPrice24h: string;
+  lowPrice24h: string;
+  ask1Price: string;
+  bid1Price: string;
+  bid1Size: string;
+  ask1Size: string;
+  price24hPcnt: string;
+  volume24h: string;
+  turnover24h: string;
+
+  // Futures specific fields
+  indexPrice?: string;
+  markPrice?: string;
+  fundingRate?: string;
+  openInterest?: string;
+  deliveryStartTime?: string;
+  deliveryTime?: string;
+  deliveryStatus?: string;
+}
+⋮----
+// Futures specific fields
+⋮----
+export interface ProofOfReservesV3 {
+  merkleRootHash: string;
+  totalReserveRatio: string;
+  list: {
+    coin: string;
+    userAssets: string;
+    platformAssets: string;
+    reserveRatio: string;
+  }[];
+}
+⋮----
+export interface IndexComponentV3 {
+  exchange: string;
+  spotPair: string;
+  equivalentPrice: string;
+  weight: string;
+}
+⋮----
+export interface IndexPriceComponentsV3 {
+  symbol: string;
+  componentList: IndexComponentV3[];
+}
+⋮----
+export interface RpiSymbolV3 {
+  category: 'spot' | 'usdt-futures' | 'coin-futures' | 'usdc-futures';
+  symbol: string;
+}
+⋮----
+/** RPI order book depth: [price, nonRpiQty, rpiQty] */
+export interface RpiOrderBookV3 {
+  a: [string, string, string][];
+  b: [string, string, string][];
+  ts: string;
+}
+⋮----
+export interface CashDividendRecordV3 {
+  symbol: string;
+  exDividendDate: string;
+  cashDividendPerShare: string;
+  cashDividendTimestamp: string;
+}
+⋮----
+export interface SpotWhaleFlowV3 {
+  volume: string;
+  date: string;
+}
+⋮----
+export interface SpotNetFlowV3 {
+  netFlow: string;
+  ts: string;
+}
+⋮----
+export interface SpotFundFlowV3 {
+  whaleBuyVolume: string;
+  dolphinBuyVolume: string;
+  fishBuyVolume: string;
+  whaleSellVolume: string;
+  dolphinSellVolume: string;
+  fishSellVolume: string;
+  whaleBuyRatio: string;
+  dolphinBuyRatio: string;
+  fishBuyRatio: string;
+  whaleSellRatio: string;
+  dolphinSellRatio: string;
+  fishSellRatio: string;
+}
+⋮----
+export interface MarginLongShortV3 {
+  longShortRatio: string;
+  ts: string;
+}
+⋮----
+export interface MarginLoanGrowthV3 {
+  growthRate: string;
+  ts: string;
+}
+⋮----
+export interface MarginIsolatedBorrowV3 {
+  borrowRate: string;
+  ts: string;
+}
+⋮----
+export interface FuturesActiveBuySellV3 {
+  buyVolume: string;
+  sellVolume: string;
+  ts: string;
+}
+⋮----
+export interface FuturesLongShortV3 {
+  longRatio: string;
+  shortRatio: string;
+  longShortRatio: string;
+  ts: string;
+}
+⋮----
+export interface FuturesPositionLongShortV3 {
+  longPositionRatio: string;
+  shortPositionRatio: string;
+  longShortPositionRatio: string;
+  ts: string;
+}
+⋮----
+export interface FuturesAccountLongShortV3 {
+  longAccountRatio: string;
+  shortAccountRatio: string;
+  longShortAccountRatio: string;
+  ts: string;
+}
+
+================
 File: src/index.ts
 ================
 
@@ -10723,6 +11069,7 @@ File: README.md
 [![last commit](https://img.shields.io/github/last-commit/tiagosiebler/bitget-api)][1]
 [![CodeFactor](https://www.codefactor.io/repository/github/tiagosiebler/bitget-api/badge)](https://www.codefactor.io/repository/github/tiagosiebler/bitget-api)
 [![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/bitget-api)
 
 <p align="center">
   <a href="https://www.npmjs.com/package/bitget-api">
@@ -13963,6 +14310,7 @@ import {
   CreateSubAccountRequestV3,
   DeleteSubAccountApiKeyRequestV3,
   FreezeSubAccountRequestV3,
+  GetAllFeeRatesRequestV3,
   GetConvertRecordsRequestV3,
   GetDepositAddressRequestV3,
   GetDepositRecordsRequestV3,
@@ -13970,6 +14318,7 @@ import {
   GetFinancialRecordsRequestV3,
   GetFundingAssetsRequestV3,
   GetMaxTransferableRequestV3,
+  GetMaxWithdrawalRequestV3,
   GetOpenInterestLimitRequestV3,
   GetSubAccountApiKeysRequestV3,
   GetSubAccountListRequestV3,
@@ -13981,9 +14330,12 @@ import {
   GetTransferableCoinsRequestV3,
   GetWithdrawAddressBookRequestV3,
   GetWithdrawRecordsRequestV3,
+  PreSetLeverageRequestV3,
   RepayRequestV3,
+  SetCollateralTypeRequestV3,
   SetDepositAccountRequestV3,
   SetLeverageRequestV3,
+  SetMarginRequestV3,
   SubAccountTransferRequestV3,
   SwitchDeductRequestV3,
   TransferRequestV3,
@@ -14054,13 +14406,19 @@ import {
 } from './types/request/v3/p2p.js';
 import {
   GetCandlesRequestV3,
+  GetCashDividendRecordsRequestV3,
   GetContractsOiRequestV3,
   GetCurrentFundingRateRequestV3,
+  GetFuturesTradingDataRequestV3,
   GetHistoryCandlesRequestV3,
   GetHistoryFundingRateRequestV3,
   GetIndexComponentsRequestV3,
   GetInstrumentsRequestV3,
+  GetLiquidationsRequestV3,
+  GetMarginIsolatedBorrowRequestV3,
+  GetMarginLoanGrowthRequestV3,
   GetMarginLoansRequestV3,
+  GetMarginLongShortRequestV3,
   GetMarketFeeGroupRequestV3,
   GetMarketScoreWeightsRequestV3,
   GetOpenInterestRequestV3,
@@ -14069,6 +14427,10 @@ import {
   GetPublicFillsRequestV3,
   GetRiskReserveAllRequestV3,
   GetRiskReserveRequestV3,
+  GetRpiOrderBookRequestV3,
+  GetSpotFundFlowRequestV3,
+  GetSpotNetFlowRequestV3,
+  GetSpotWhaleFlowRequestV3,
   GetTickersRequestV3,
 } from './types/request/v3/public.js';
 import {
@@ -14083,6 +14445,7 @@ import {
   CancelAllOrdersRequestV3,
   CancelBatchOrdersRequestV3,
   CancelOrderRequestV3,
+  CancelRealityOrderRequestV3,
   CloseAllPositionsRequestV3,
   CountdownCancelAllRequestV3,
   GetCurrentPositionRequestV3,
@@ -14095,22 +14458,28 @@ import {
   ModifyOrderRequestV3,
   PlaceBatchOrdersRequestV3,
   PlaceOrderRequestV3,
+  PlaceRealityOrderRequestV3,
 } from './types/request/v3/trade.js';
 import {
   AccountAssetsV3,
   AccountDeltaInfoV3,
   AccountInfoV3,
   AccountSettingsV3,
+  AllSymbolFeeRateV3,
+  CollateralTypeConfigV3,
   ConvertRecordV3,
   CreateSubAccountApiKeyResponseV3,
   CreateSubAccountResponseV3,
+  CustomCollateralCoinV3,
   DepositAddressV3,
   DepositRecordV3,
   FinancialRecordV3,
   FundingAssetV3,
   MaxTransferableV3,
+  MaxWithdrawalV3,
   OpenInterestLimitV3,
   PaymentCoinV3,
+  PreSetLeverageV3,
   RepayableCoinV3,
   RepayResponseV3,
   SubAccountApiKeyV3,
@@ -14192,13 +14561,22 @@ import {
 } from './types/response/v3/p2p.js';
 import {
   CandlestickV3,
+  CashDividendRecordV3,
   ContractOiV3,
   CurrentFundingRateV3,
   DiscountRateV3,
+  FuturesAccountLongShortV3,
+  FuturesActiveBuySellV3,
+  FuturesLongShortV3,
+  FuturesPositionLongShortV3,
   HistoryFundingRateV3,
   IndexPriceComponentsV3,
   InstrumentV3,
+  LiquidationsV3,
+  MarginIsolatedBorrowV3,
+  MarginLoanGrowthV3,
   MarginLoanV3,
+  MarginLongShortV3,
   MarketFeeGroupV3,
   MarketScoreWeightV3,
   OpenInterestV3,
@@ -14209,6 +14587,11 @@ import {
   RiskReserveAllV3,
   RiskReserveHourV3,
   RiskReserveV3,
+  RpiOrderBookV3,
+  RpiSymbolV3,
+  SpotFundFlowV3,
+  SpotNetFlowV3,
+  SpotWhaleFlowV3,
   TickerV3,
 } from './types/response/v3/public.js';
 import {
@@ -14226,6 +14609,7 @@ import {
   FillV3,
   GetMaxOpenAvailableResponseV3,
   HistoryOrderV3,
+  LoanDataV3,
   ModifyOrderResponseV3,
   OrderInfoV3,
   PlaceBatchOrdersResponseV3,
@@ -14298,6 +14682,102 @@ getInstruments(
 getMarketFeeGroup(
     params: GetMarketFeeGroupRequestV3,
 ): Promise<APIResponse<MarketFeeGroupV3[]>>
+⋮----
+/**
+   * Get Liquidations History - Query historical liquidation order data (last 3 days)
+   */
+getLiquidations(
+    params: GetLiquidationsRequestV3,
+): Promise<APIResponse<LiquidationsV3>>
+⋮----
+/**
+   * Get RPI Symbols - Trading pairs supporting Retail Price Improvement
+   */
+getRpiSymbols(): Promise<APIResponse<RpiSymbolV3[]>>
+⋮----
+/**
+   * Get RPI OrderBook - Depth with RPI and non-RPI quantities per price level
+   */
+getRpiOrderBook(
+    params: GetRpiOrderBookRequestV3,
+): Promise<APIResponse<RpiOrderBookV3>>
+⋮----
+/**
+   * Get Cash Dividend Records - RWA stock futures cash dividend records
+   */
+getCashDividendRecords(
+    params: GetCashDividendRecordsRequestV3,
+): Promise<APIResponse<CashDividendRecordV3[]>>
+⋮----
+/**
+   * Get Spot Whale Net Flow Data
+   */
+getSpotWhaleFlow(
+    params: GetSpotWhaleFlowRequestV3,
+): Promise<APIResponse<SpotWhaleFlowV3[]>>
+⋮----
+/**
+   * Get Spot Fund Flow Data
+   */
+getSpotFundFlow(
+    params: GetSpotFundFlowRequestV3,
+): Promise<APIResponse<SpotFundFlowV3>>
+⋮----
+/**
+   * Get Spot 24H Net Capital Inflow Data
+   */
+getSpotNetFlow(
+    params: GetSpotNetFlowRequestV3,
+): Promise<APIResponse<SpotNetFlowV3[]>>
+⋮----
+/**
+   * Get Margin Long Short Ratio Data
+   */
+getMarginLongShort(
+    params: GetMarginLongShortRequestV3,
+): Promise<APIResponse<MarginLongShortV3[]>>
+⋮----
+/**
+   * Get Margin Loan Growth Rate Data
+   */
+getMarginLoanGrowth(
+    params: GetMarginLoanGrowthRequestV3,
+): Promise<APIResponse<MarginLoanGrowthV3[]>>
+⋮----
+/**
+   * Get Isolated Margin Borrowing Ratio Data
+   */
+getMarginIsolatedBorrow(
+    params: GetMarginIsolatedBorrowRequestV3,
+): Promise<APIResponse<MarginIsolatedBorrowV3[]>>
+⋮----
+/**
+   * Get Futures Active Buy Sell Volume Data
+   */
+getFuturesActiveBuySell(
+    params: GetFuturesTradingDataRequestV3,
+): Promise<APIResponse<FuturesActiveBuySellV3[]>>
+⋮----
+/**
+   * Get Futures Long Short Ratio Data
+   */
+getFuturesLongShort(
+    params: GetFuturesTradingDataRequestV3,
+): Promise<APIResponse<FuturesLongShortV3[]>>
+⋮----
+/**
+   * Get Futures Active Long Short Position Data
+   */
+getFuturesPositionLongShort(
+    params: GetFuturesTradingDataRequestV3,
+): Promise<APIResponse<FuturesPositionLongShortV3[]>>
+⋮----
+/**
+   * Get Futures Active Long Short Account Data
+   */
+getFuturesAccountLongShort(
+    params: GetFuturesTradingDataRequestV3,
+): Promise<APIResponse<FuturesAccountLongShortV3[]>>
 ⋮----
 /**
    * Get Market Maker Score Weight - Query score weights per symbol
@@ -14526,6 +15006,42 @@ setHoldMode(params: {
 }): Promise<APIResponse<string>>
 ⋮----
 /**
+   * Get Collateral Type - Query unified account collateral configuration
+   */
+getCollateralType(): Promise<APIResponse<CollateralTypeConfigV3>>
+⋮----
+/**
+   * Set Collateral Type - Configure unified account collateral type
+   */
+setCollateralType(
+    params: SetCollateralTypeRequestV3,
+): Promise<APIResponse<string>>
+⋮----
+/**
+   * Get Custom Collateral Coins - Platform-supported custom collateral coins
+   */
+getCustomCollateralCoins(): Promise<APIResponse<CustomCollateralCoinV3[]>>
+⋮----
+/**
+   * Pre Set Leverage - Preview leverage adjustment impact without applying
+   */
+preSetLeverage(
+    params: PreSetLeverageRequestV3,
+): Promise<APIResponse<PreSetLeverageV3>>
+⋮----
+/**
+   * Set Margin - Adjust isolated margin position margin amount
+   */
+setMargin(params: SetMarginRequestV3): Promise<APIResponse<string>>
+⋮----
+/**
+   * Get Max Withdrawal - Max withdrawable amount for a coin in unified account
+   */
+getMaxWithdrawal(
+    params: GetMaxWithdrawalRequestV3,
+): Promise<APIResponse<MaxWithdrawalV3>>
+⋮----
+/**
    * Get Financial Records
    */
 getFinancialRecords(params: GetFinancialRecordsRequestV3): Promise<
@@ -14609,6 +15125,13 @@ getFeeRate(params: GetFeeRateRequestV3): Promise<
     }>
   > {
     return this.getPrivate('/api/v3/account/fee-rate', params);
+⋮----
+/**
+   * Get All Symbol Fee Rates - Query fee rates for all trading pairs under a product type
+   */
+getAllFeeRates(
+    params: GetAllFeeRatesRequestV3,
+): Promise<APIResponse<AllSymbolFeeRateV3[]>>
 ⋮----
 /**
    * Get Max Transferable
@@ -14866,6 +15389,25 @@ submitNewOrder(
 modifyOrder(
     params: ModifyOrderRequestV3,
 ): Promise<APIResponse<ModifyOrderResponseV3>>
+⋮----
+/**
+   * Place Reality Order - Limit or market order for Reality stock trading pairs
+   */
+placeRealityOrder(
+    params: PlaceRealityOrderRequestV3,
+): Promise<APIResponse<PlaceOrderResponseV3>>
+⋮----
+/**
+   * Cancel Reality Order - Cancel an unfilled or partially filled Reality stock order
+   */
+cancelRealityOrder(
+    params: CancelRealityOrderRequestV3,
+): Promise<APIResponse<CancelOrderResponseV3>>
+⋮----
+/**
+   * Get Loan Data - Query current loan data for the unified trading account
+   */
+getLoanData(): Promise<APIResponse<LoanDataV3>>
 ⋮----
 /**
    * Cancel Order
@@ -15421,7 +15963,7 @@ File: package.json
 ================
 {
   "name": "bitget-api",
-  "version": "3.1.8",
+  "version": "3.1.11",
   "description": "Complete Node.js & JavaScript SDK for Bitget V1-V3 REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "scripts": {
     "test": "jest",
@@ -15473,9 +16015,7 @@ File: package.json
     "jest": "^29.7.0",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3"
-  },
-  "optionalDependencies": {
+    "typescript": "^5.7.3",
     "source-map-loader": "^4.0.0",
     "ts-loader": "^9.5.4",
     "webpack": "^5.74.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitget-api",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitget-api",
-      "version": "3.1.9",
+      "version": "3.1.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitget-api",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "description": "Complete Node.js & JavaScript SDK for Bitget V1-V3 REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "scripts": {
     "test": "jest",

--- a/src/rest-client-v3.ts
+++ b/src/rest-client-v3.ts
@@ -5,6 +5,7 @@ import {
   CreateSubAccountRequestV3,
   DeleteSubAccountApiKeyRequestV3,
   FreezeSubAccountRequestV3,
+  GetAllFeeRatesRequestV3,
   GetConvertRecordsRequestV3,
   GetDepositAddressRequestV3,
   GetDepositRecordsRequestV3,
@@ -12,6 +13,7 @@ import {
   GetFinancialRecordsRequestV3,
   GetFundingAssetsRequestV3,
   GetMaxTransferableRequestV3,
+  GetMaxWithdrawalRequestV3,
   GetOpenInterestLimitRequestV3,
   GetSubAccountApiKeysRequestV3,
   GetSubAccountListRequestV3,
@@ -23,9 +25,12 @@ import {
   GetTransferableCoinsRequestV3,
   GetWithdrawAddressBookRequestV3,
   GetWithdrawRecordsRequestV3,
+  PreSetLeverageRequestV3,
   RepayRequestV3,
+  SetCollateralTypeRequestV3,
   SetDepositAccountRequestV3,
   SetLeverageRequestV3,
+  SetMarginRequestV3,
   SubAccountTransferRequestV3,
   SwitchDeductRequestV3,
   TransferRequestV3,
@@ -96,13 +101,19 @@ import {
 } from './types/request/v3/p2p.js';
 import {
   GetCandlesRequestV3,
+  GetCashDividendRecordsRequestV3,
   GetContractsOiRequestV3,
   GetCurrentFundingRateRequestV3,
+  GetFuturesTradingDataRequestV3,
   GetHistoryCandlesRequestV3,
   GetHistoryFundingRateRequestV3,
   GetIndexComponentsRequestV3,
   GetInstrumentsRequestV3,
+  GetLiquidationsRequestV3,
+  GetMarginIsolatedBorrowRequestV3,
+  GetMarginLoanGrowthRequestV3,
   GetMarginLoansRequestV3,
+  GetMarginLongShortRequestV3,
   GetMarketFeeGroupRequestV3,
   GetMarketScoreWeightsRequestV3,
   GetOpenInterestRequestV3,
@@ -111,6 +122,10 @@ import {
   GetPublicFillsRequestV3,
   GetRiskReserveAllRequestV3,
   GetRiskReserveRequestV3,
+  GetRpiOrderBookRequestV3,
+  GetSpotFundFlowRequestV3,
+  GetSpotNetFlowRequestV3,
+  GetSpotWhaleFlowRequestV3,
   GetTickersRequestV3,
 } from './types/request/v3/public.js';
 import {
@@ -125,6 +140,7 @@ import {
   CancelAllOrdersRequestV3,
   CancelBatchOrdersRequestV3,
   CancelOrderRequestV3,
+  CancelRealityOrderRequestV3,
   CloseAllPositionsRequestV3,
   CountdownCancelAllRequestV3,
   GetCurrentPositionRequestV3,
@@ -137,22 +153,28 @@ import {
   ModifyOrderRequestV3,
   PlaceBatchOrdersRequestV3,
   PlaceOrderRequestV3,
+  PlaceRealityOrderRequestV3,
 } from './types/request/v3/trade.js';
 import {
   AccountAssetsV3,
   AccountDeltaInfoV3,
   AccountInfoV3,
   AccountSettingsV3,
+  AllSymbolFeeRateV3,
+  CollateralTypeConfigV3,
   ConvertRecordV3,
   CreateSubAccountApiKeyResponseV3,
   CreateSubAccountResponseV3,
+  CustomCollateralCoinV3,
   DepositAddressV3,
   DepositRecordV3,
   FinancialRecordV3,
   FundingAssetV3,
   MaxTransferableV3,
+  MaxWithdrawalV3,
   OpenInterestLimitV3,
   PaymentCoinV3,
+  PreSetLeverageV3,
   RepayableCoinV3,
   RepayResponseV3,
   SubAccountApiKeyV3,
@@ -234,13 +256,22 @@ import {
 } from './types/response/v3/p2p.js';
 import {
   CandlestickV3,
+  CashDividendRecordV3,
   ContractOiV3,
   CurrentFundingRateV3,
   DiscountRateV3,
+  FuturesAccountLongShortV3,
+  FuturesActiveBuySellV3,
+  FuturesLongShortV3,
+  FuturesPositionLongShortV3,
   HistoryFundingRateV3,
   IndexPriceComponentsV3,
   InstrumentV3,
+  LiquidationsV3,
+  MarginIsolatedBorrowV3,
+  MarginLoanGrowthV3,
   MarginLoanV3,
+  MarginLongShortV3,
   MarketFeeGroupV3,
   MarketScoreWeightV3,
   OpenInterestV3,
@@ -251,6 +282,11 @@ import {
   RiskReserveAllV3,
   RiskReserveHourV3,
   RiskReserveV3,
+  RpiOrderBookV3,
+  RpiSymbolV3,
+  SpotFundFlowV3,
+  SpotNetFlowV3,
+  SpotWhaleFlowV3,
   TickerV3,
 } from './types/response/v3/public.js';
 import {
@@ -268,6 +304,7 @@ import {
   FillV3,
   GetMaxOpenAvailableResponseV3,
   HistoryOrderV3,
+  LoanDataV3,
   ModifyOrderResponseV3,
   OrderInfoV3,
   PlaceBatchOrdersResponseV3,
@@ -392,6 +429,130 @@ export class RestClientV3 extends BaseRestClient {
     params: GetMarketFeeGroupRequestV3,
   ): Promise<APIResponse<MarketFeeGroupV3[]>> {
     return this.get('/api/v3/market/fee-group', params);
+  }
+
+  /**
+   * Get Liquidations History - Query historical liquidation order data (last 3 days)
+   */
+  getLiquidations(
+    params: GetLiquidationsRequestV3,
+  ): Promise<APIResponse<LiquidationsV3>> {
+    return this.get('/api/v3/market/liquidations', params);
+  }
+
+  /**
+   * Get RPI Symbols - Trading pairs supporting Retail Price Improvement
+   */
+  getRpiSymbols(): Promise<APIResponse<RpiSymbolV3[]>> {
+    return this.get('/api/v3/market/rpi-symbols');
+  }
+
+  /**
+   * Get RPI OrderBook - Depth with RPI and non-RPI quantities per price level
+   */
+  getRpiOrderBook(
+    params: GetRpiOrderBookRequestV3,
+  ): Promise<APIResponse<RpiOrderBookV3>> {
+    return this.get('/api/v3/market/rpi-orderbook', params);
+  }
+
+  /**
+   * Get Cash Dividend Records - RWA stock futures cash dividend records
+   */
+  getCashDividendRecords(
+    params: GetCashDividendRecordsRequestV3,
+  ): Promise<APIResponse<CashDividendRecordV3[]>> {
+    return this.get('/api/v3/market/cash-dividend-records', params);
+  }
+
+  /**
+   * Get Spot Whale Net Flow Data
+   */
+  getSpotWhaleFlow(
+    params: GetSpotWhaleFlowRequestV3,
+  ): Promise<APIResponse<SpotWhaleFlowV3[]>> {
+    return this.get('/api/v3/market/spot-whale-flow', params);
+  }
+
+  /**
+   * Get Spot Fund Flow Data
+   */
+  getSpotFundFlow(
+    params: GetSpotFundFlowRequestV3,
+  ): Promise<APIResponse<SpotFundFlowV3>> {
+    return this.get('/api/v3/market/spot-fund-flow', params);
+  }
+
+  /**
+   * Get Spot 24H Net Capital Inflow Data
+   */
+  getSpotNetFlow(
+    params: GetSpotNetFlowRequestV3,
+  ): Promise<APIResponse<SpotNetFlowV3[]>> {
+    return this.get('/api/v3/market/spot-net-flow', params);
+  }
+
+  /**
+   * Get Margin Long Short Ratio Data
+   */
+  getMarginLongShort(
+    params: GetMarginLongShortRequestV3,
+  ): Promise<APIResponse<MarginLongShortV3[]>> {
+    return this.get('/api/v3/market/margin-long-short', params);
+  }
+
+  /**
+   * Get Margin Loan Growth Rate Data
+   */
+  getMarginLoanGrowth(
+    params: GetMarginLoanGrowthRequestV3,
+  ): Promise<APIResponse<MarginLoanGrowthV3[]>> {
+    return this.get('/api/v3/market/margin-loan-growth', params);
+  }
+
+  /**
+   * Get Isolated Margin Borrowing Ratio Data
+   */
+  getMarginIsolatedBorrow(
+    params: GetMarginIsolatedBorrowRequestV3,
+  ): Promise<APIResponse<MarginIsolatedBorrowV3[]>> {
+    return this.get('/api/v3/market/margin-isolated-borrow', params);
+  }
+
+  /**
+   * Get Futures Active Buy Sell Volume Data
+   */
+  getFuturesActiveBuySell(
+    params: GetFuturesTradingDataRequestV3,
+  ): Promise<APIResponse<FuturesActiveBuySellV3[]>> {
+    return this.get('/api/v3/market/futures-active-buy-sell', params);
+  }
+
+  /**
+   * Get Futures Long Short Ratio Data
+   */
+  getFuturesLongShort(
+    params: GetFuturesTradingDataRequestV3,
+  ): Promise<APIResponse<FuturesLongShortV3[]>> {
+    return this.get('/api/v3/market/futures-long-short', params);
+  }
+
+  /**
+   * Get Futures Active Long Short Position Data
+   */
+  getFuturesPositionLongShort(
+    params: GetFuturesTradingDataRequestV3,
+  ): Promise<APIResponse<FuturesPositionLongShortV3[]>> {
+    return this.get('/api/v3/market/futures-position-long-short', params);
+  }
+
+  /**
+   * Get Futures Active Long Short Account Data
+   */
+  getFuturesAccountLongShort(
+    params: GetFuturesTradingDataRequestV3,
+  ): Promise<APIResponse<FuturesAccountLongShortV3[]>> {
+    return this.get('/api/v3/market/futures-account-long-short', params);
   }
 
   /**
@@ -681,6 +842,54 @@ export class RestClientV3 extends BaseRestClient {
   }
 
   /**
+   * Get Collateral Type - Query unified account collateral configuration
+   */
+  getCollateralType(): Promise<APIResponse<CollateralTypeConfigV3>> {
+    return this.getPrivate('/api/v3/account/collateral-type');
+  }
+
+  /**
+   * Set Collateral Type - Configure unified account collateral type
+   */
+  setCollateralType(
+    params: SetCollateralTypeRequestV3,
+  ): Promise<APIResponse<string>> {
+    return this.postPrivate('/api/v3/account/set-collateral-type', params);
+  }
+
+  /**
+   * Get Custom Collateral Coins - Platform-supported custom collateral coins
+   */
+  getCustomCollateralCoins(): Promise<APIResponse<CustomCollateralCoinV3[]>> {
+    return this.get('/api/v3/account/custom-collateral-coins');
+  }
+
+  /**
+   * Pre Set Leverage - Preview leverage adjustment impact without applying
+   */
+  preSetLeverage(
+    params: PreSetLeverageRequestV3,
+  ): Promise<APIResponse<PreSetLeverageV3>> {
+    return this.getPrivate('/api/v3/account/pre-set-leverage', params);
+  }
+
+  /**
+   * Set Margin - Adjust isolated margin position margin amount
+   */
+  setMargin(params: SetMarginRequestV3): Promise<APIResponse<string>> {
+    return this.postPrivate('/api/v3/account/set-margin', params);
+  }
+
+  /**
+   * Get Max Withdrawal - Max withdrawable amount for a coin in unified account
+   */
+  getMaxWithdrawal(
+    params: GetMaxWithdrawalRequestV3,
+  ): Promise<APIResponse<MaxWithdrawalV3>> {
+    return this.getPrivate('/api/v3/account/max-withdrawal', params);
+  }
+
+  /**
    * Get Financial Records
    */
   getFinancialRecords(params: GetFinancialRecordsRequestV3): Promise<
@@ -775,6 +984,15 @@ export class RestClientV3 extends BaseRestClient {
     }>
   > {
     return this.getPrivate('/api/v3/account/fee-rate', params);
+  }
+
+  /**
+   * Get All Symbol Fee Rates - Query fee rates for all trading pairs under a product type
+   */
+  getAllFeeRates(
+    params: GetAllFeeRatesRequestV3,
+  ): Promise<APIResponse<AllSymbolFeeRateV3[]>> {
+    return this.getPrivate('/api/v3/account/all-fee-rate', params);
   }
 
   /**
@@ -1081,6 +1299,31 @@ export class RestClientV3 extends BaseRestClient {
     params: ModifyOrderRequestV3,
   ): Promise<APIResponse<ModifyOrderResponseV3>> {
     return this.postPrivate('/api/v3/trade/modify-order', params);
+  }
+
+  /**
+   * Place Reality Order - Limit or market order for Reality stock trading pairs
+   */
+  placeRealityOrder(
+    params: PlaceRealityOrderRequestV3,
+  ): Promise<APIResponse<PlaceOrderResponseV3>> {
+    return this.postPrivate('/api/v3/trade/place-reality-order', params);
+  }
+
+  /**
+   * Cancel Reality Order - Cancel an unfilled or partially filled Reality stock order
+   */
+  cancelRealityOrder(
+    params: CancelRealityOrderRequestV3,
+  ): Promise<APIResponse<CancelOrderResponseV3>> {
+    return this.postPrivate('/api/v3/trade/cancel-reality-order', params);
+  }
+
+  /**
+   * Get Loan Data - Query current loan data for the unified trading account
+   */
+  getLoanData(): Promise<APIResponse<LoanDataV3>> {
+    return this.getPrivate('/api/v3/trade/loan-data');
   }
 
   /**

--- a/src/types/request/v3/account.ts
+++ b/src/types/request/v3/account.ts
@@ -14,11 +14,27 @@ export interface SetLeverageRequestV3 {
   leverage: string;
   coin?: string;
   posSide?: 'long' | 'short';
+  /** Futures only. Defaults to crossed */
+  marginMode?: 'crossed' | 'isolated';
+  /** Isolated two-way mode: long leverage. Takes priority over leverage when both set */
+  longLeverage?: string;
+  /** Isolated two-way mode: short leverage. Takes priority over leverage when both set */
+  shortLeverage?: string;
+}
+
+export interface GetAllFeeRatesRequestV3 {
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  symbol?: string;
 }
 
 export interface GetConvertRecordsRequestV3 {
-  fromCoin: string;
-  toCoin: string;
+  fromCoin?: string;
+  toCoin?: string;
   startTime?: string;
   endTime?: string;
   limit?: string;
@@ -93,6 +109,7 @@ export interface GetSubAccountListRequestV3 {
 // Transfer Request Types
 
 export interface TransferRequestV3 {
+  clientOid?: string;
   fromType:
     | 'spot'
     | 'p2p'
@@ -238,6 +255,8 @@ export interface GetSubDepositRecordsRequestV3 {
 export interface WithdrawRequestV3 {
   coin: string;
   chain?: string;
+  /** Deduct from funding, uta, and/or otc accounts (comma-separated). Order: funding -> otc -> uta */
+  accountType?: string;
   transferType: 'on_chain' | 'internal_transfer';
   address: string;
   innerToType?: 'uid' | 'email' | 'mobile';
@@ -303,4 +322,34 @@ export interface GetTaxRecordsRequestV3 {
   endTime: string;
   limit?: string;
   cursor?: string;
+}
+
+export type CollateralTypeV3 = 'mainstream' | 'all' | 'custom';
+
+export interface SetCollateralTypeRequestV3 {
+  collateralType: CollateralTypeV3;
+  /** Required when collateralType=custom. Comma-separated coin names */
+  collateralCoins?: string;
+}
+
+export interface PreSetLeverageRequestV3 {
+  category: 'MARGIN' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  coin?: string;
+  marginMode: 'isolated' | 'cross';
+  leverage?: string;
+  longLeverage?: string;
+  shortLeverage?: string;
+}
+
+export interface SetMarginRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  posSide: 'long' | 'short';
+  operation: 'add' | 'remove';
+  amount: string;
+}
+
+export interface GetMaxWithdrawalRequestV3 {
+  coin: string;
 }

--- a/src/types/request/v3/public.ts
+++ b/src/types/request/v3/public.ts
@@ -55,7 +55,15 @@ export interface GetContractsOiRequestV3 {
 }
 
 export interface GetCurrentFundingRateRequestV3 {
-  symbol: string;
+  category?: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+}
+
+export interface GetLiquidationsRequestV3 {
+  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol?: string;
+  limit?: string;
+  cursor?: string;
 }
 
 export interface GetHistoryFundingRateRequestV3 {
@@ -102,7 +110,7 @@ export interface GetInstrumentsRequestV3 {
 
 export interface GetMarketFeeGroupRequestV3 {
   category: 'SPOT' | 'FUTURES';
-  group?: 'GROUP_A' | 'GROUP_B' | 'GROUP_C';
+  group?: 'DEFAULT' | 'GROUP_A' | 'GROUP_B' | 'GROUP_C';
 }
 
 export interface GetMarketScoreWeightsRequestV3 {
@@ -122,4 +130,52 @@ export interface GetTickersRequestV3 {
 
 export interface GetIndexComponentsRequestV3 {
   symbol: string;
+}
+
+export interface GetRpiOrderBookRequestV3 {
+  category: 'SPOT' | 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  symbol: string;
+  limit?: string;
+}
+
+export interface GetCashDividendRecordsRequestV3 {
+  symbol: string;
+  type: 'pending' | 'paid';
+  cursor?: string;
+  limit?: string;
+}
+
+export interface GetSpotWhaleFlowRequestV3 {
+  symbol: string;
+}
+
+export interface GetSpotFundFlowRequestV3 {
+  symbol: string;
+  period?: string;
+}
+
+export interface GetSpotNetFlowRequestV3 {
+  symbol: string;
+}
+
+export interface GetMarginLongShortRequestV3 {
+  symbol: string;
+  period?: '24h' | '30d';
+  coin?: string;
+}
+
+export interface GetMarginLoanGrowthRequestV3 {
+  symbol: string;
+  period?: string;
+  coin?: string;
+}
+
+export interface GetMarginIsolatedBorrowRequestV3 {
+  symbol: string;
+  period?: string;
+}
+
+export interface GetFuturesTradingDataRequestV3 {
+  symbol: string;
+  period?: string;
 }

--- a/src/types/request/v3/strategy.ts
+++ b/src/types/request/v3/strategy.ts
@@ -12,7 +12,12 @@ export type StrategyTriggerByV3 = 'market' | 'mark';
 export type StrategyTriggerOrderTypeV3 = 'limit' | 'market';
 
 export interface PlaceStrategyOrderRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
   symbol: string;
   clientOid?: string;
   type?: StrategyOrderTypeV3;
@@ -60,12 +65,22 @@ export interface CancelStrategyOrderRequestV3 {
 }
 
 export interface GetUnfilledStrategyOrdersRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
   type?: StrategyOrderTypeV3;
 }
 
 export interface GetHistoryStrategyOrdersRequestV3 {
-  category: 'USDT-FUTURES' | 'COIN-FUTURES' | 'USDC-FUTURES';
+  category:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
   type?: StrategyOrderTypeV3;
   startTime?: string;
   endTime?: string;

--- a/src/types/request/v3/trade.ts
+++ b/src/types/request/v3/trade.ts
@@ -114,6 +114,36 @@ export interface ModifyOrderRequestV3 {
   qty?: string;
   price?: string;
   autoCancel?: 'yes' | 'no';
+  symbol?: string;
+  category?:
+    | 'SPOT'
+    | 'MARGIN'
+    | 'USDT-FUTURES'
+    | 'COIN-FUTURES'
+    | 'USDC-FUTURES';
+  tpTriggerBy?: 'market' | 'mark';
+  slTriggerBy?: 'market' | 'mark';
+  takeProfit?: string;
+  stopLoss?: string;
+  tpOrderType?: 'limit' | 'market';
+  slOrderType?: 'limit' | 'market';
+  tpLimitPrice?: string;
+  slLimitPrice?: string;
+}
+
+export interface PlaceRealityOrderRequestV3 {
+  symbol: string;
+  side: 'buy' | 'sell';
+  orderType: 'limit' | 'market';
+  qty: string;
+  price?: string;
+  clientOid?: string;
+}
+
+export interface CancelRealityOrderRequestV3 {
+  symbol: string;
+  orderId?: string;
+  clientOid?: string;
 }
 
 export interface PlaceBatchOrdersRequestV3 {

--- a/src/types/response/v3/account.ts
+++ b/src/types/response/v3/account.ts
@@ -1,4 +1,6 @@
 // Account Management Response Types
+import type { CollateralTypeV3 } from '../../request/v3/account.js';
+
 export interface AccountSymbolConfigV3 {
   category: string;
   symbol: string;
@@ -65,6 +67,10 @@ export interface AccountAssetV3 {
   available: string;
   debt: string;
   locked: string;
+  /** Position value in USD */
+  positionValue?: string;
+  /** Account leverage (non-negative) */
+  leverage?: string;
 }
 
 export interface AccountAssetsV3 {
@@ -101,6 +107,10 @@ export interface FinancialRecordV3 {
   fee: string;
   balance: string;
   ts: string;
+  /** crossed | isolated */
+  positionType?: string;
+  positionAmount?: string;
+  positionBalance?: string;
 }
 
 export interface PaymentCoinV3 {
@@ -186,8 +196,15 @@ export interface WithdrawAddressBookV3 {
 
 // Transfer Response Types
 
+export interface AllSymbolFeeRateV3 {
+  symbol: string;
+  makerFeeRate: string;
+  takerFeeRate: string;
+}
+
 export interface TransferResponseV3 {
   transferId: string;
+  clientOid?: string;
 }
 
 export interface SubTransferRecordV3 {
@@ -305,4 +322,29 @@ export interface TaxRecordV3 {
   fee: string;
   balance: string;
   ts: string;
+}
+
+export interface CollateralTypeConfigV3 {
+  collateralType: CollateralTypeV3;
+  /** Returned when collateralType=custom */
+  collateralCoins?: string;
+}
+
+export interface CustomCollateralCoinV3 {
+  collateralCoin: string;
+}
+
+export interface PreSetLeverageV3 {
+  estMaxOpen?: string;
+  estMaxBorrowable?: string;
+  requiredMargin: string;
+  marginChange: string;
+}
+
+export interface MaxWithdrawalV3 {
+  coin: string;
+  otcMaxWithdrawal: string;
+  spotMaxWithdrawal: string;
+  utaMaxWithdrawal: string;
+  totalMaxWithdrawal: string;
 }

--- a/src/types/response/v3/public.ts
+++ b/src/types/response/v3/public.ts
@@ -29,6 +29,8 @@ export interface CurrentFundingRateV3 {
   nextUpdate: string;
   minFundingRate: string;
   maxFundingRate: string;
+  cashDividend?: string;
+  cashDividendNextUpdate?: string;
 }
 
 export interface DiscountRateTierV3 {
@@ -139,6 +141,9 @@ export interface InstrumentV3 {
   maintainTime: string;
   areaSymbol?: string;
 
+  /** yes = Reality stock token, no = non-Reality stock token */
+  isReality?: 'yes' | 'no';
+
   // Futures specific fields
   makerFeeRate?: string;
   takerFeeRate?: string;
@@ -175,6 +180,8 @@ export interface MarketFeeGroupLabelV3 {
 export interface MarketFeeGroupTierV3 {
   level: string;
   makerFeeRate: string;
+  /** PRO1~PRO6 only. Taker fee rate in decimal form */
+  takerFeeRate?: string;
 }
 
 export interface MarketFeeGroupV3 {
@@ -191,6 +198,19 @@ export interface MarketScoreWeightV3 {
   requiredSpread: string;
   minMakerVolume: string;
   weight: string;
+}
+
+export interface LiquidationV3 {
+  symbol: string;
+  side: 'buy' | 'sell';
+  price: string;
+  amount: string;
+  ts: string;
+}
+
+export interface LiquidationsV3 {
+  list: LiquidationV3[];
+  cursor?: string;
 }
 
 export interface OrderBookV3 {
@@ -245,4 +265,90 @@ export interface IndexComponentV3 {
 export interface IndexPriceComponentsV3 {
   symbol: string;
   componentList: IndexComponentV3[];
+}
+
+export interface RpiSymbolV3 {
+  category: 'spot' | 'usdt-futures' | 'coin-futures' | 'usdc-futures';
+  symbol: string;
+}
+
+/** RPI order book depth: [price, nonRpiQty, rpiQty] */
+export interface RpiOrderBookV3 {
+  a: [string, string, string][];
+  b: [string, string, string][];
+  ts: string;
+}
+
+export interface CashDividendRecordV3 {
+  symbol: string;
+  exDividendDate: string;
+  cashDividendPerShare: string;
+  cashDividendTimestamp: string;
+}
+
+export interface SpotWhaleFlowV3 {
+  volume: string;
+  date: string;
+}
+
+export interface SpotNetFlowV3 {
+  netFlow: string;
+  ts: string;
+}
+
+export interface SpotFundFlowV3 {
+  whaleBuyVolume: string;
+  dolphinBuyVolume: string;
+  fishBuyVolume: string;
+  whaleSellVolume: string;
+  dolphinSellVolume: string;
+  fishSellVolume: string;
+  whaleBuyRatio: string;
+  dolphinBuyRatio: string;
+  fishBuyRatio: string;
+  whaleSellRatio: string;
+  dolphinSellRatio: string;
+  fishSellRatio: string;
+}
+
+export interface MarginLongShortV3 {
+  longShortRatio: string;
+  ts: string;
+}
+
+export interface MarginLoanGrowthV3 {
+  growthRate: string;
+  ts: string;
+}
+
+export interface MarginIsolatedBorrowV3 {
+  borrowRate: string;
+  ts: string;
+}
+
+export interface FuturesActiveBuySellV3 {
+  buyVolume: string;
+  sellVolume: string;
+  ts: string;
+}
+
+export interface FuturesLongShortV3 {
+  longRatio: string;
+  shortRatio: string;
+  longShortRatio: string;
+  ts: string;
+}
+
+export interface FuturesPositionLongShortV3 {
+  longPositionRatio: string;
+  shortPositionRatio: string;
+  longShortPositionRatio: string;
+  ts: string;
+}
+
+export interface FuturesAccountLongShortV3 {
+  longAccountRatio: string;
+  shortAccountRatio: string;
+  longShortAccountRatio: string;
+  ts: string;
 }

--- a/src/types/response/v3/trade.ts
+++ b/src/types/response/v3/trade.ts
@@ -64,6 +64,7 @@ export interface OrderInfoV3 {
   orderStatus: string;
   posSide: string;
   holdMode: string;
+  delegateType?: string;
   reduceOnly: string;
   feeDetail: FeeDetailV3[];
   cancelReason: string;
@@ -202,6 +203,19 @@ export interface CurrentPositionV3 {
   closeFeeTotal: string;
   createdTime: string;
   updatedTime: string;
+}
+
+export interface LoanDataDebtCoinV3 {
+  coin: string;
+  debt: string;
+  interestFreeAmount: string;
+  interestRateNextHour: string;
+}
+
+export interface LoanDataV3 {
+  currentLoans: string;
+  interestPaymentTime: string;
+  debtCoinList: LoanDataDebtCoinV3[];
 }
 
 export interface ModifyOrderResponseV3 {

--- a/src/types/websockets/ws-events.ts
+++ b/src/types/websockets/ws-events.ts
@@ -95,3 +95,13 @@ export interface WSPositionSnapshotUMCBL extends WsBaseEvent<'snapshot'> {
   };
   data: WsPositionSnapshotDataUMCBL[];
 }
+
+/** Classic V2 depth channel push data. checksum removed May 2026 - use seq instead */
+export interface WsDepthBookDataV2 {
+  asks: [string, string][];
+  bids: [string, string][];
+  ts: string;
+  seq: string;
+  /** Futures books channel only - previous push serial number */
+  pseq?: string;
+}


### PR DESCRIPTION

New RestClientV3 methods (18)
Account:

getCollateralType() / setCollateralType()
getCustomCollateralCoins() (public)
preSetLeverage()
setMargin()
getMaxWithdrawal()
Market / trading data:

getRpiSymbols() / getRpiOrderBook()
getCashDividendRecords()
getSpotWhaleFlow() / getSpotFundFlow() / getSpotNetFlow()
getMarginLongShort() / getMarginLoanGrowth() / getMarginIsolatedBorrow()
getFuturesActiveBuySell() / getFuturesLongShort() / getFuturesPositionLongShort() / getFuturesAccountLongShort()
Other changes
WsDepthBookDataV2 - seq + optional pseq (checksum removed)
Full request/response types for all of the above
24 new example files + updated docs/endpointFunctionList.md / llms.txt